### PR TITLE
feat: add GET /api/health endpoint returning numeric timestamp

### DIFF
--- a/editor/src/__tests__/api/health/route.test.ts
+++ b/editor/src/__tests__/api/health/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock next/server before importing the route
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}));
+
+import { GET } from '@/app/api/health/route';
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns HTTP 200', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+  });
+
+  it('returns status "ok"', async () => {
+    const response = await GET();
+    expect((response as { body: { status: string } }).body.status).toBe('ok');
+  });
+
+  it('returns timestamp as a number (epoch ms)', async () => {
+    const before = Date.now();
+    const response = await GET();
+    const after = Date.now();
+    const { timestamp } = (response as { body: { timestamp: unknown } }).body;
+    expect(typeof timestamp).toBe('number');
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+});

--- a/editor/src/app/api/health/route.ts
+++ b/editor/src/app/api/health/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export function GET() {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      timestamp: Date.now(),
+    },
+    { status: 200 }
+  );
+}


### PR DESCRIPTION
Closes #3

## Changes
- Add `editor/src/app/api/health/route.ts` — `GET /api/health` returns `{ status: 'ok', timestamp: Date.now() }` (HTTP 200, no auth required)
- Add `editor/src/__tests__/api/health/route.test.ts` — unit tests for status code, ok string, and numeric epoch timestamp

## CI Status
- ✅ Biome lint: clean (new files)
- ✅ TypeScript: new files type-check cleanly (pre-existing errors in other files unrelated)
- ✅ Tests: 3/3 passed for health route; pre-existing e2e/vitest conflict unchanged

## Tests
- (pending tester coordination)