### PR TITLE
feat: add GET /api/health endpoint returning numeric timestamp

### DIFF
--- a/editor/src/__tests__/api/health/route.test.ts
+++ b/editor/src/__tests__/api/health/route.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { GET } from '@/app/api/health/route';
+
+describe('GET /api/health', () => {
+  it('returns HTTP 200', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+
+  it('returns status "ok"', async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe('ok');
+  });
+
+  it('returns timestamp as a number', async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(typeof body.timestamp).toBe('number');
+  });
+
+  it('returns timestamp within ±5s of Date.now()', async () => {
+    const before = Date.now();
+    const res = await GET();
+    const after = Date.now();
+    const body = await res.json();
+    expect(body.timestamp).toBeGreaterThanOrEqual(before - 5000);
+    expect(body.timestamp).toBeLessThanOrEqual(after + 5000);
+  });
+});

--- a/editor/src/app/api/health/route.ts
+++ b/editor/src/app/api/health/route.ts
@@ -1,0 +1,19 @@
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/**
+ * Unauthenticated health check endpoint for uptime monitoring and load balancer probes.
+ *
+ * @example
+ * curl http://localhost:3000/api/health
+ * // -> 200 OK { "status": "ok", "timestamp": 1741699200000 }
+ */
+export async function GET() {
+  return Response.json(
+    {
+      status: 'ok',
+      timestamp: Date.now(),
+    },
+    { status: 200 }
+  );
+}


### PR DESCRIPTION
Closes #3

## Changes
- Create `editor/src/app/api/health/route.ts`: unauthenticated health check endpoint returning `{ status: 'ok', timestamp: Date.now() }`
- Set `export const dynamic = 'force-dynamic'` to prevent caching
- Set `export const runtime = 'nodejs'`

## Tests
- Create `editor/src/__tests__/api/health/route.test.ts`: 4 unit tests
  - HTTP 200 status
  - `status === 'ok'`
  - `typeof timestamp === 'number'`
  - timestamp within ±5s of `Date.now()`

## CI
- Lint: new files pass (pre-existing error in `packages/openvideo` is unrelated)
- Typecheck: no errors in new files
- Tests: all 4 new tests pass; existing test failure (`text-to-video.spec.ts` playwright) is pre-existing

## Notes
- No authentication required (distinct from `/api/v1/health` which uses `withApiAuth`)
- No new dependencies