### PR TITLE
fix: add session auth to /api/uploads/presign endpoint

### DIFF
--- a/editor/src/app/api/uploads/presign/route.ts
+++ b/editor/src/app/api/uploads/presign/route.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import { type NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
 import { config } from '@/lib/config';
 import { R2StorageService } from '@/lib/r2';
 
 interface PresignRequest {
-  userId: string;
   fileNames: string[];
 }
 
@@ -18,8 +18,16 @@ const r2 = new R2StorageService({
 
 export async function POST(request: NextRequest) {
   try {
+    const session = await auth.api.getSession({ headers: request.headers });
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const userId = session.user.id;
+
     const body: PresignRequest = await request.json();
-    const { userId = 'mockuser', fileNames } = body;
+    const { fileNames } = body;
 
     if (!fileNames || !Array.isArray(fileNames) || fileNames.length === 0) {
       return NextResponse.json(


### PR DESCRIPTION
Closes #8

## Changes
- Add `auth.api.getSession({ headers: request.headers })` before processing the presign request
- Return `401 Unauthorized` with `{ error: 'Unauthorized' }` if no valid session exists
- Derive `userId` from `session.user.id` — never from the request body
- Remove `userId` from the `PresignRequest` interface entirely
- Remove the `'mockuser'` fallback

Follows the exact auth pattern from `editor/src/app/api/ai/tts/route.ts`.

## Tests
- (pending tester coordination)