### PR TITLE
fix: auto-fix lint errors (biome format + deprecated config)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,16 +7,20 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.json"],
-    "experimentalScannerIgnores": [
-      "**/node_modules/**",
-      "**/dist/**",
-      "**/build/**",
-      "**/.next/**",
-      "**/coverage/**",
-      "**/*.d.ts",
-      "**/pnpm-lock.yaml",
-      "**/turbo.json"
+    "includes": [
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.js",
+      "**/*.jsx",
+      "**/*.json",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/build",
+      "!**/.next",
+      "!**/coverage",
+      "!**/*.d.ts",
+      "!**/pnpm-lock.yaml",
+      "!**/turbo.json"
     ]
   },
   "formatter": {

--- a/editor/src/app/(marketing)/page.tsx
+++ b/editor/src/app/(marketing)/page.tsx
@@ -98,7 +98,7 @@ function OrbBackground() {
 
 /* ─── Screenshot Placeholder ──────────────────────────────────────── */
 
-function ScreenshotPlaceholder({
+function _ScreenshotPlaceholder({
   label,
   aspect = '16/10',
   id,

--- a/editor/src/remotion/scenes/KineticHeadline.tsx
+++ b/editor/src/remotion/scenes/KineticHeadline.tsx
@@ -4,8 +4,6 @@ import {
   spring,
   useCurrentFrame,
   useVideoConfig,
-  Easing,
-  Sequence,
 } from 'remotion';
 import { COLORS } from '../constants';
 

--- a/editor/src/remotion/scenes/LogoReveal.tsx
+++ b/editor/src/remotion/scenes/LogoReveal.tsx
@@ -4,7 +4,6 @@ import {
   spring,
   useCurrentFrame,
   useVideoConfig,
-  Easing,
 } from 'remotion';
 import { COLORS } from '../constants';
 

--- a/integrations/n8n-nodes-openvideo/nodes/OpenVideo/OpenVideo.node.ts
+++ b/integrations/n8n-nodes-openvideo/nodes/OpenVideo/OpenVideo.node.ts
@@ -210,7 +210,7 @@ export class OpenVideo implements INodeType {
             let mergeData: Record<string, any> = {};
             try {
               mergeData = JSON.parse(mergeDataStr);
-            } catch (parseError) {
+            } catch (_parseError) {
               throw new NodeOperationError(
                 this.getNode(),
                 'Invalid JSON in Merge Data field',

--- a/integrations/n8n-nodes-openvideo/nodes/OpenVideo/OpenVideoTrigger.node.ts
+++ b/integrations/n8n-nodes-openvideo/nodes/OpenVideo/OpenVideoTrigger.node.ts
@@ -67,7 +67,7 @@ export class OpenVideoTrigger implements INodeType {
 
           const webhooks = response.data || [];
           return webhooks.some((webhook: any) => webhook.url === webhookUrl);
-        } catch (error: any) {
+        } catch (_error: any) {
           // If we can't check, assume it doesn't exist
           return false;
         }
@@ -136,7 +136,7 @@ export class OpenVideoTrigger implements INodeType {
           delete webhookData.webhookId;
 
           return true;
-        } catch (error) {
+        } catch (_error) {
           // Best-effort cleanup - log but don't throw
           // This prevents errors when the webhook was already deleted manually
           return false;

--- a/integrations/zapier-openvideo/authentication.js
+++ b/integrations/zapier-openvideo/authentication.js
@@ -1,13 +1,13 @@
 const baseUrl =
   process.env.OPENVIDEO_API_URL || 'https://app.openvideo.dev/api/v1';
 
-const test = async (z, bundle) => {
+const test = async (z, _bundle) => {
   const response = await z.request({ url: `${baseUrl}/me` });
   return response.data;
 };
 
-const addApiKeyToHeader = (request, z, bundle) => {
-  if (bundle.authData && bundle.authData.apiKey) {
+const addApiKeyToHeader = (request, _z, bundle) => {
+  if (bundle.authData?.apiKey) {
     request.headers.Authorization = `Bearer ${bundle.authData.apiKey}`;
   }
   return request;

--- a/integrations/zapier-openvideo/searches/listTemplates.js
+++ b/integrations/zapier-openvideo/searches/listTemplates.js
@@ -1,7 +1,7 @@
 const baseUrl =
   process.env.OPENVIDEO_API_URL || 'https://app.openvideo.dev/api/v1';
 
-const perform = async (z, bundle) => {
+const perform = async (z, _bundle) => {
   const response = await z.request({
     url: `${baseUrl}/templates`,
   });

--- a/integrations/zapier-openvideo/test/authentication.test.js
+++ b/integrations/zapier-openvideo/test/authentication.test.js
@@ -1,10 +1,10 @@
 const zapier = require('zapier-platform-core');
 const App = require('../index');
-const appTester = zapier.createAppTester(App);
+const _appTester = zapier.createAppTester(App);
 
 describe('authentication', () => {
   it('should authenticate with valid API key', async () => {
-    const bundle = {
+    const _bundle = {
       authData: { apiKey: process.env.OPENVIDEO_API_KEY || 'sk_live_test' },
     };
     // This test requires a running API, so mark as integration test

--- a/integrations/zapier-openvideo/triggers/renderCompleted.js
+++ b/integrations/zapier-openvideo/triggers/renderCompleted.js
@@ -21,7 +21,7 @@ const performUnsubscribe = async (z, bundle) => {
   });
 };
 
-const perform = async (z, bundle) => {
+const perform = async (_z, bundle) => {
   const event = bundle.cleanedRequest;
   return [
     {
@@ -32,7 +32,7 @@ const perform = async (z, bundle) => {
   ];
 };
 
-const performList = async (z, bundle) => {
+const performList = async (z, _bundle) => {
   const response = await z.request({
     url: `${baseUrl}/renders`,
     params: { status: 'completed', limit: '3' },

--- a/packages/node/examples/basic.ts
+++ b/packages/node/examples/basic.ts
@@ -1,5 +1,5 @@
 import { Renderer } from '@designcombo/node';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 // Example JSON configuration
 const videoConfig = {

--- a/packages/node/src/renderer.ts
+++ b/packages/node/src/renderer.ts
@@ -1,10 +1,10 @@
 import { chromium, type Browser, type Page } from 'playwright';
-import { writeFile, readFile } from 'fs/promises';
-import { EventEmitter } from 'events';
+import { writeFile, readFile } from 'node:fs/promises';
+import { EventEmitter } from 'node:events';
 import express, { type Express } from 'express';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
-import type { Server } from 'http';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Server } from 'node:http';
 import type { RenderConfig, RenderEventMap, RenderProgress } from './types.js';
 
 export class Renderer extends EventEmitter {
@@ -150,7 +150,7 @@ export class Renderer extends EventEmitter {
             // @ts-expect-error
             window.renderError = errMsg;
           }, String(err));
-        } catch (e) {
+        } catch (_e) {
           // Ignore evaluate errors if page is closed
         }
       });
@@ -253,7 +253,7 @@ export class Renderer extends EventEmitter {
     }
     if (this.server) {
       await new Promise<void>((resolve) => {
-        this.server!.close(() => resolve());
+        this.server?.close(() => resolve());
       });
       this.server = null;
     }

--- a/packages/node/src/sample.ts
+++ b/packages/node/src/sample.ts
@@ -1,7 +1,7 @@
 import { Renderer } from './index.js';
-import { resolve, dirname } from 'path';
-import { readFile } from 'fs/promises';
-import { fileURLToPath } from 'url';
+import { resolve, dirname } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/openvideo/vite.config.ts
+++ b/packages/openvideo/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import dts from 'vite-plugin-dts';
-import path from 'path';
+import path from 'node:path';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 
 // https://vitejs.dev/config/

--- a/packages/openvideo/vitest.config.ts
+++ b/packages/openvideo/vitest.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vitest/config';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { playwright } from '@vitest/browser-playwright';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/packages/openvideo/vitest.setup.ts
+++ b/packages/openvideo/vitest.setup.ts
@@ -1,2 +1,1 @@
-import { vi } from 'vitest';
 import 'pixi.js';


### PR DESCRIPTION
Closes #13

## Changes
- Updated `biome.json`: replaced deprecated `experimentalScannerIgnores` with negated patterns in `files.includes`
- Applied Biome auto-format (safe + unsafe fixes) to 1632+ files
- Added `node:` protocol to Node.js built-in imports in `packages/openvideo`
- Removed unused import in `vitest.setup.ts`

## CI
- Lint: ✅ (previously ❌)
- Typecheck: ✅

Auto-generated by nightly CI cron (2026-03-12)