### PR TITLE
fix: provide DATABASE_URL fallback for prisma generate at build time

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "DATABASE_URL=${DATABASE_URL:-postgresql://build:build@localhost:5432/build} prisma generate && next build",
     "postinstall": "prisma generate",
     "start": "next start",
     "test": "vitest",


### PR DESCRIPTION
Closes #22

## Summary
- Add `DATABASE_URL` fallback in editor build script so `prisma generate` succeeds in CI/container environments without a live database
- Uses shell parameter expansion: `${DATABASE_URL:-postgresql://build:build@localhost:5432/build}`
- The dummy URL is only used for schema generation, not actual database connections

## CI verification
- Lint: ✅
- Typecheck: ✅
- Build: ✅ (all 4 turbo tasks pass)

Auto-fix by Auto-Fixer cron job.
Original finding by dev agent.