### PR TITLE
test: cover Resend email integration across sending paths

### DIFF
--- a/editor/src/__tests__/email/auth-emails.test.ts
+++ b/editor/src/__tests__/email/auth-emails.test.ts
@@ -3,11 +3,13 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 const { mockEmailsSend, mockResend, mockConsoleInfo, mockConsoleError } =
   vi.hoisted(() => ({
     mockEmailsSend: vi.fn(),
-    mockResend: vi.fn().mockImplementation(() => ({
-      emails: {
-        send: mockEmailsSend,
-      },
-    })),
+    mockResend: vi.fn(function MockResend() {
+      return {
+        emails: {
+          send: mockEmailsSend,
+        },
+      };
+    }),
     mockConsoleInfo: vi.fn(),
     mockConsoleError: vi.fn(),
   }));

--- a/editor/src/__tests__/email/credits-emails.test.ts
+++ b/editor/src/__tests__/email/credits-emails.test.ts
@@ -2,17 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockEmailsSend, mockResend, mockPrisma } = vi.hoisted(() => ({
   mockEmailsSend: vi.fn(),
-  mockResend: vi.fn().mockImplementation(() => ({
-    emails: {
-      send: mockEmailsSend,
-    },
-  })),
+  mockResend: vi.fn(function MockResend() {
+    return {
+      emails: {
+        send: mockEmailsSend,
+      },
+    };
+  }),
   mockPrisma: {
     organization: {
-      findUnique: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
       update: vi.fn(),
     },
-    user: {
+    member: {
       findFirst: vi.fn(),
     },
   },
@@ -41,16 +43,18 @@ describe('Low-credit warning emails', () => {
   });
 
   it('should send a low-credit warning email when the organization is below the threshold', async () => {
-    mockPrisma.organization.findUnique.mockResolvedValue({
-      id: 'org-1',
-      name: 'Vizora Studio',
-      creditsRemaining: 4,
+    mockPrisma.organization.findUniqueOrThrow.mockResolvedValue({
+      creditBalance: 4,
+      monthlyAllotment: 20,
       lowCreditWarningShown: false,
       lowCreditEmailSentAt: null,
+      tier: 'pro',
     });
-    mockPrisma.user.findFirst.mockResolvedValue({
-      id: 'owner-1',
-      email: 'owner@vizora.dev',
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
     });
     mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
 
@@ -65,12 +69,12 @@ describe('Low-credit warning emails', () => {
   });
 
   it('should not send a low-credit warning email when a warning is already shown', async () => {
-    mockPrisma.organization.findUnique.mockResolvedValue({
-      id: 'org-1',
-      name: 'Vizora Studio',
-      creditsRemaining: 3,
+    mockPrisma.organization.findUniqueOrThrow.mockResolvedValue({
+      creditBalance: 3,
+      monthlyAllotment: 20,
       lowCreditWarningShown: true,
       lowCreditEmailSentAt: null,
+      tier: 'pro',
     });
 
     await checkAndWarnLowCredits('org-1');
@@ -79,13 +83,14 @@ describe('Low-credit warning emails', () => {
   });
 
   it('should not send a low-credit warning email twice within twenty-four hours', async () => {
-    mockPrisma.organization.findUnique.mockResolvedValue({
-      id: 'org-1',
-      name: 'Vizora Studio',
-      creditsRemaining: 2,
+    mockPrisma.organization.findUniqueOrThrow.mockResolvedValue({
+      creditBalance: 2,
+      monthlyAllotment: 20,
       lowCreditWarningShown: false,
       lowCreditEmailSentAt: new Date(),
+      tier: 'pro',
     });
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
 
     await checkAndWarnLowCredits('org-1');
 
@@ -93,12 +98,12 @@ describe('Low-credit warning emails', () => {
   });
 
   it('should not send a low-credit warning email when the organization is above the threshold', async () => {
-    mockPrisma.organization.findUnique.mockResolvedValue({
-      id: 'org-1',
-      name: 'Vizora Studio',
-      creditsRemaining: 100,
+    mockPrisma.organization.findUniqueOrThrow.mockResolvedValue({
+      creditBalance: 100,
+      monthlyAllotment: 200,
       lowCreditWarningShown: false,
       lowCreditEmailSentAt: null,
+      tier: 'pro',
     });
 
     await checkAndWarnLowCredits('org-1');

--- a/editor/src/__tests__/email/deletion-warning-emails.test.ts
+++ b/editor/src/__tests__/email/deletion-warning-emails.test.ts
@@ -17,23 +17,27 @@ const {
 
   return {
     mockEmailsSend: vi.fn(),
-    mockResend: vi.fn().mockImplementation(() => ({
-      emails: {
-        send: mockEmailsSend,
-      },
-    })),
+    mockResend: vi.fn(function MockResend() {
+      return {
+        emails: {
+          send: mockEmailsSend,
+        },
+      };
+    }),
     mockPrisma: {
       render: {
         findUnique: vi.fn(),
         update: vi.fn(),
       },
+      $disconnect: vi.fn(),
     },
     mockWorkerOn: vi.fn(),
     mockRedisConnection: {},
-    mockBullWorker: vi.fn().mockImplementation((_name, processor) => {
+    mockBullWorker: vi.fn(function MockWorker(_name, processor) {
       capturedProcessor = processor;
       return {
         on: mockWorkerOn,
+        close: vi.fn(),
       };
     }),
     getCapturedProcessor: () => capturedProcessor,
@@ -81,8 +85,10 @@ describe('Deletion warning worker emails', () => {
       },
       user: {
         email: 'creator@vizora.dev',
+        name: 'Creator',
       },
-      downloadUrl: 'https://cdn.vizora.dev/renders/render-1.mp4',
+      outputUrl: 'https://cdn.vizora.dev/renders/render-1.mp4',
+      expiresAt: new Date('2026-03-20T00:00:00.000Z'),
     });
     mockPrisma.render.update.mockResolvedValue({ id: 'render-1' });
 
@@ -128,8 +134,10 @@ describe('Deletion warning worker emails', () => {
       },
       user: {
         email: 'creator@vizora.dev',
+        name: 'Creator',
       },
-      downloadUrl: 'https://cdn.vizora.dev/renders/render-1.mp4',
+      outputUrl: 'https://cdn.vizora.dev/renders/render-1.mp4',
+      expiresAt: new Date('2026-03-20T00:00:00.000Z'),
     });
     mockPrisma.render.update.mockResolvedValue({ id: 'render-1' });
 

--- a/editor/src/__tests__/email/stripe-emails.test.ts
+++ b/editor/src/__tests__/email/stripe-emails.test.ts
@@ -2,16 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockEmailsSend, mockResend, mockPrisma } = vi.hoisted(() => ({
   mockEmailsSend: vi.fn(),
-  mockResend: vi.fn().mockImplementation(() => ({
-    emails: {
-      send: mockEmailsSend,
-    },
-  })),
+  mockResend: vi.fn(function MockResend() {
+    return {
+      emails: {
+        send: mockEmailsSend,
+      },
+    };
+  }),
   mockPrisma: {
     organization: {
       findUnique: vi.fn(),
+      update: vi.fn(),
     },
-    user: {
+    member: {
       findFirst: vi.fn(),
     },
   },
@@ -40,19 +43,22 @@ describe('Billing email flows', () => {
     mockPrisma.organization.findUnique.mockResolvedValue({
       id: 'org-1',
       name: 'Vizora Studio',
-      slug: 'vizora-studio',
     });
-    mockPrisma.user.findFirst.mockResolvedValue({
-      id: 'user-1',
-      email: 'owner@vizora.dev',
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
     });
 
-    // CODER NOTE: The architect plan expects this handler to keep using the public function signature
-    // while its internals look up the org owner and billing URL.
     await handlePaymentFailed({
-      organizationId: 'org-1',
-      customerId: 'cus_123',
-      invoiceId: 'in_123',
+      data: {
+        object: {
+          id: 'in_123',
+          customer: 'cus_123',
+        },
+      },
     } as never);
 
     expect(mockEmailsSend).toHaveBeenCalledTimes(1);
@@ -67,14 +73,17 @@ describe('Billing email flows', () => {
     mockPrisma.organization.findUnique.mockResolvedValue({
       id: 'org-1',
       name: 'Vizora Studio',
-      slug: 'vizora-studio',
     });
-    mockPrisma.user.findFirst.mockResolvedValue(null);
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue(null);
 
     await handlePaymentFailed({
-      organizationId: 'org-1',
-      customerId: 'cus_456',
-      invoiceId: 'in_456',
+      data: {
+        object: {
+          id: 'in_456',
+          customer: 'cus_456',
+        },
+      },
     } as never);
 
     expect(mockEmailsSend).not.toHaveBeenCalled();
@@ -85,17 +94,22 @@ describe('Billing email flows', () => {
     mockPrisma.organization.findUnique.mockResolvedValue({
       id: 'org-1',
       name: 'Vizora Studio',
-      slug: 'vizora-studio',
     });
-    mockPrisma.user.findFirst.mockResolvedValue({
-      id: 'user-1',
-      email: 'owner@vizora.dev',
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
     });
 
     await handlePaymentFailed({
-      organizationId: 'org-1',
-      customerId: 'cus_789',
-      invoiceId: 'in_789',
+      data: {
+        object: {
+          id: 'in_789',
+          customer: 'cus_789',
+        },
+      },
     } as never);
 
     expect(mockEmailsSend).not.toHaveBeenCalled();

--- a/editor/src/lib/auth.ts
+++ b/editor/src/lib/auth.ts
@@ -4,34 +4,135 @@ import { organization } from 'better-auth/plugins';
 import { prisma } from './db';
 import { Resend } from 'resend';
 
-// Initialize Resend client for email sending (optional in development)
-const resend = process.env.RESEND_API_KEY
-  ? new Resend(process.env.RESEND_API_KEY)
-  : null;
+function getResendClient() {
+  const resendApiKey = process.env.RESEND_API_KEY;
+  return resendApiKey ? new Resend(resendApiKey) : null;
+}
 
-async function sendEmail(to: string, subject: string, html: string) {
+async function deliverEmail(to: string, subject: string, html: string) {
+  const resend = getResendClient();
   const fromEmail = process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev';
+
   if (!resend) {
-    console.log(
+    console.info(
       `[Auth] Email skipped (no RESEND_API_KEY): to=${to} subject="${subject}"`
     );
     return;
   }
-  const { data, error } = await resend.emails.send({
-    from: fromEmail,
-    to,
-    subject,
-    html,
-  });
-  if (error) {
-    console.error(
-      `[Auth] Failed to send email: to=${to} subject="${subject}" error=${JSON.stringify(error)}`
-    );
-  } else {
-    console.log(
+
+  try {
+    const { data, error } = await resend.emails.send({
+      from: fromEmail,
+      to,
+      subject,
+      html,
+    });
+
+    if (error) {
+      console.error(
+        `[Auth] Failed to send email: to=${to} subject="${subject}" error=${JSON.stringify(error)}`
+      );
+      return;
+    }
+
+    console.info(
       `[Auth] Email sent: id=${data?.id} to=${to} subject="${subject}"`
     );
+  } catch (error) {
+    console.error('[Auth] Failed to send email:', error);
   }
+}
+
+export async function sendEmail(to: string, subject: string, html: string) {
+  await deliverEmail(to, subject, html);
+}
+
+export async function sendVerificationEmailHandler({
+  user,
+  url,
+}: {
+  user: { email: string; name?: string };
+  url: string;
+}) {
+  if (!getResendClient()) {
+    console.info(`[Auth] Verification URL for ${user.email}: ${url}`);
+  }
+
+  await deliverEmail(
+    user.email,
+    'Verify your email address',
+    `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2>Welcome to Vizora!</h2>
+      <p>Please verify your email address by clicking the link below:</p>
+      <p>
+        <a href="${url}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px;">
+          Verify Email
+        </a>
+      </p>
+      <p style="color: #666; font-size: 14px;">
+        If you didn't create an account, you can safely ignore this email.
+      </p>
+    </div>`
+  );
+}
+
+export async function sendResetPasswordHandler({
+  user,
+  url,
+}: {
+  user: { email: string; name?: string };
+  url: string;
+}) {
+  await deliverEmail(
+    user.email,
+    'Reset your password',
+    `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2>Password Reset Request</h2>
+      <p>You requested to reset your password. Click the link below to set a new password:</p>
+      <p>
+        <a href="${url}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px;">
+          Reset Password
+        </a>
+      </p>
+      <p style="color: #666; font-size: 14px;">
+        If you didn't request a password reset, you can safely ignore this email.
+      </p>
+    </div>`
+  );
+}
+
+export async function sendInvitationEmailHandler({
+  email,
+  invitation,
+  organization: org,
+  invitationLink,
+}: {
+  email: string;
+  invitation: { id: string };
+  organization: { name: string };
+  inviter?: { user?: { name?: string } };
+  invitationLink?: string;
+}) {
+  const baseUrl = process.env.BETTER_AUTH_URL || 'http://localhost:3000';
+  const resolvedInvitationLink =
+    invitationLink || `${baseUrl}/accept-invitation?id=${invitation.id}`;
+
+  await deliverEmail(
+    email,
+    `You've been invited to join ${org.name}`,
+    `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2>Organization Invitation</h2>
+      <p>You've been invited to join <strong>${org.name}</strong> on Vizora!</p>
+      <p>
+        <a href="${resolvedInvitationLink}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px;">
+          Accept Invitation
+        </a>
+      </p>
+      <p style="color: #666; font-size: 14px;">
+        If you don't want to accept this invitation, you can safely ignore this email.
+      </p>
+    </div>`
+  );
 }
 
 // Better Auth server configuration
@@ -47,57 +148,8 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: !!process.env.RESEND_API_KEY,
-    sendVerificationEmail: async ({
-      user,
-      url,
-    }: {
-      user: { email: string; name: string };
-      url: string;
-    }) => {
-      if (!resend) {
-        console.log(`[Auth] Verification URL for ${user.email}: ${url}`);
-      }
-      await sendEmail(
-        user.email,
-        'Verify your email address',
-        `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2>Welcome to Vizora!</h2>
-          <p>Please verify your email address by clicking the link below:</p>
-          <p>
-            <a href="${url}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px;">
-              Verify Email
-            </a>
-          </p>
-          <p style="color: #666; font-size: 14px;">
-            If you didn't create an account, you can safely ignore this email.
-          </p>
-        </div>`
-      );
-    },
-    sendResetPassword: async ({
-      user,
-      url,
-    }: {
-      user: { email: string; name: string };
-      url: string;
-    }) => {
-      await sendEmail(
-        user.email,
-        'Reset your password',
-        `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2>Password Reset Request</h2>
-          <p>You requested to reset your password. Click the link below to set a new password:</p>
-          <p>
-            <a href="${url}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px;">
-              Reset Password
-            </a>
-          </p>
-          <p style="color: #666; font-size: 14px;">
-            If you didn't request a password reset, you can safely ignore this email.
-          </p>
-        </div>`
-      );
-    },
+    sendVerificationEmail: sendVerificationEmailHandler,
+    sendResetPassword: sendResetPasswordHandler,
   },
 
   socialProviders: {
@@ -113,27 +165,7 @@ export const auth = betterAuth({
 
   plugins: [
     organization({
-      sendInvitationEmail: async ({ email, invitation, organization: org }) => {
-        const baseUrl = process.env.BETTER_AUTH_URL || 'http://localhost:3000';
-        const invitationLink = `${baseUrl}/accept-invitation?id=${invitation.id}`;
-
-        await sendEmail(
-          email,
-          `You've been invited to join ${org.name}`,
-          `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-            <h2>Organization Invitation</h2>
-            <p>You've been invited to join <strong>${org.name}</strong> on Vizora!</p>
-            <p>
-              <a href="${invitationLink}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px;">
-                Accept Invitation
-              </a>
-            </p>
-            <p style="color: #666; font-size: 14px;">
-              If you don't want to accept this invitation, you can safely ignore this email.
-            </p>
-          </div>`
-        );
-      },
+      sendInvitationEmail: sendInvitationEmailHandler,
     }),
   ],
 

--- a/editor/src/lib/credits.ts
+++ b/editor/src/lib/credits.ts
@@ -4,9 +4,14 @@ import { prisma } from '@/lib/db';
 import { isLowCredit } from '@/lib/billing';
 import { Resend } from 'resend';
 
-const resendApiKey = process.env.RESEND_API_KEY;
-const resendFromEmail = process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev';
-const resend = resendApiKey ? new Resend(resendApiKey) : null;
+function getResendClient() {
+  const resendApiKey = process.env.RESEND_API_KEY;
+  return resendApiKey ? new Resend(resendApiKey) : null;
+}
+
+function getResendFromEmail() {
+  return process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev';
+}
 
 // Result types
 export type DeductResult =
@@ -202,6 +207,8 @@ export async function checkAndWarnLowCredits(
       data: { lowCreditWarningShown: true },
     });
 
+    const resend = getResendClient();
+
     // Send email if Resend configured and not sent recently
     if (resend) {
       const now = new Date();
@@ -233,7 +240,7 @@ export async function checkAndWarnLowCredits(
 
           try {
             await resend.emails.send({
-              from: resendFromEmail,
+              from: getResendFromEmail(),
               to: owner.user.email,
               subject: 'Low Credit Warning - Vizora',
               html: `

--- a/editor/src/lib/stripe-handlers.ts
+++ b/editor/src/lib/stripe-handlers.ts
@@ -4,16 +4,15 @@ import { stripe } from '@/lib/stripe';
 import { prisma } from '@/lib/db';
 import { TIER_CONFIG, type TierName } from '@/lib/billing';
 
-// Optional Resend for email notifications (follows same pattern as auth.ts)
-let resend: any = null;
-if (process.env.RESEND_API_KEY) {
-  import('resend').then(({ Resend }) => {
-    resend = new Resend(process.env.RESEND_API_KEY);
-  });
-} else {
-  console.warn(
-    '[Stripe Handlers] RESEND_API_KEY not configured - email notifications disabled'
-  );
+async function getResendClient() {
+  const resendApiKey = process.env.RESEND_API_KEY;
+
+  if (!resendApiKey) {
+    return null;
+  }
+
+  const { Resend } = await import('resend');
+  return new Resend(resendApiKey);
 }
 
 export async function handleCheckoutComplete(event: Stripe.Event) {
@@ -297,6 +296,8 @@ export async function handlePaymentFailed(event: Stripe.Event) {
       subscriptionStatus: 'past_due',
     },
   });
+
+  const resend = await getResendClient();
 
   // Send email notification to organization owner
   const owner = await prisma.member.findFirst({


### PR DESCRIPTION
Closes #36

## Changes
- added/updated integration tests for auth, billing, low-credit, and deletion-warning email flows
- exported auth email handlers and switched auth/credits/stripe Resend initialization to runtime lookup for testable env-driven behavior
- aligned email sender fallback to `noreply@vizora.dev` and verified outgoing payload assertions across all current Resend-backed paths

## Audit summary
Covered current Resend-backed paths under `editor/src/`:
- auth verification email
- auth password reset email
- organization invitation email
- low-credit warning email
- payment failed notification email
- deletion warning worker email

No additional implemented Resend-backed send paths were found under `editor/src/` beyond the list above.

## CI
- Changed-file Biome check: PASS
- `pnpm check-types`: PASS
- `cd editor && pnpm vitest run`: PASS
- `cd editor && pnpm build`: PASS
- `pnpm check`: BLOCKED by pre-existing unrelated Biome diagnostics in `packages/openvideo/src/*`, `editor/src/*`, and `docs/src/*`
