### PR TITLE
fix: resolve test failures on main

### DIFF
--- a/editor/src/__tests__/api/batch-export/route.test.ts
+++ b/editor/src/__tests__/api/batch-export/route.test.ts
@@ -55,14 +55,32 @@ function makeGetRequest(): Request {
   });
 }
 
-function makePostRequest(fields: Record<string, string | Blob>): Request {
-  const fd = new FormData();
-  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
-  return new Request('http://localhost/api/batch-export', {
+/**
+ * Creates a mock Request with a `formData()` method that returns the given
+ * fields. This avoids jsdom/undici FormData incompatibilities in Node 22.
+ */
+function makePostRequest(fields: { file?: Blob; filename?: string }): Request {
+  const req = new Request('http://localhost/api/batch-export', {
     method: 'POST',
     headers: { cookie: 'session=x' },
-    body: fd,
   });
+
+  // Override formData() to return a native FormData with controlled values
+  const fd = new FormData();
+  if (fields.file) {
+    fd.append(
+      'file',
+      new File([fields.file], 'upload.mp4', {
+        type: fields.file.type,
+      })
+    );
+  }
+  if (fields.filename !== undefined) {
+    fd.append('filename', fields.filename);
+  }
+  (req as any).formData = () => Promise.resolve(fd);
+
+  return req;
 }
 
 // ---------------------------------------------------------------------------

--- a/editor/src/app/api/pexels/route.ts
+++ b/editor/src/app/api/pexels/route.ts
@@ -19,13 +19,6 @@ export async function GET(req: NextRequest) {
   const session = await requireSession(req);
   if (!session) return unauthorizedResponse();
 
-  if (!PEXELS_API_KEY) {
-    return NextResponse.json(
-      { error: 'PEXELS_API_KEY is not configured' },
-      { status: 500 }
-    );
-  }
-
   const { searchParams } = new URL(req.url);
   const parsed = pexelsQuerySchema.safeParse({
     type: searchParams.get('type') ?? undefined,
@@ -34,6 +27,13 @@ export async function GET(req: NextRequest) {
     per_page: searchParams.get('per_page') ?? undefined,
   });
   if (!parsed.success) return zodErrorResponse(parsed.error);
+
+  if (!PEXELS_API_KEY) {
+    return NextResponse.json(
+      { error: 'PEXELS_API_KEY is not configured' },
+      { status: 500 }
+    );
+  }
 
   const { type, query, page, per_page } = parsed.data;
 


### PR DESCRIPTION
## Summary
- **Pexels route** (`editor/src/app/api/pexels/route.ts`): moved Zod validation before `PEXELS_API_KEY` check so invalid input returns 400 instead of 500 when the env var is missing in test environments
- **Batch-export tests** (`editor/src/__tests__/api/batch-export/route.test.ts`): mock `req.formData()` to avoid jsdom/undici `FormData` incompatibility in Node 22 (jsdom `Blob` fails undici's webidl assertion)

Closes #28

## Test plan
- [x] `pnpm vitest run` — 6 test files, 61 tests pass, 0 failures
- [x] `pnpm check` — no errors (340 pre-existing warnings)
- [x] `pnpm check-types` — passes
- [ ] CI workflow (`.github/workflows/ci.yml`) created locally but requires `workflow` scope on GitHub token to push — to be added separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)