### PR TITLE
fix: validate audio proxy payloads

### DIFF
--- a/editor/src/app/api/audio/music/route.ts
+++ b/editor/src/app/api/audio/music/route.ts
@@ -6,10 +6,18 @@ import {
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
-// Passthrough schema — body is forwarded to external worker.
-// Ensures the body is a valid JSON object; actual field validation
-// is the responsibility of the downstream worker.
-const audioMusicSchema = z.object({}).passthrough();
+const audioMusicSchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(80).default(20),
+    page: z.coerce.number().int().min(1).max(100).default(1),
+    query: z
+      .object({
+        keys: z.array(z.string().trim().min(1).max(200)).max(10).optional(),
+      })
+      .strict()
+      .default({}),
+  })
+  .strict();
 
 export async function POST(req: NextRequest) {
   const session = await requireSession(req);

--- a/editor/src/app/api/audio/sfx/route.ts
+++ b/editor/src/app/api/audio/sfx/route.ts
@@ -6,10 +6,18 @@ import {
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
-// Passthrough schema — body is forwarded to external worker.
-// Ensures the body is a valid JSON object; actual field validation
-// is the responsibility of the downstream worker.
-const audioSfxSchema = z.object({}).passthrough();
+const audioSfxSchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(80).default(20),
+    page: z.coerce.number().int().min(1).max(100).default(1),
+    query: z
+      .object({
+        keys: z.array(z.string().trim().min(1).max(200)).max(10).optional(),
+      })
+      .strict()
+      .default({}),
+  })
+  .strict();
 
 export async function POST(req: NextRequest) {
   const session = await requireSession(req);


### PR DESCRIPTION
$Closes #54\n\n## Changes\n- replace passthrough Zod schemas on `/api/audio/music` and `/api/audio/sfx`\n- validate and bound `limit`, `page`, and `query.keys` before forwarding requests\n- reject unknown top-level and nested fields to avoid proxying arbitrary JSON\n\n## Validation\n- `COREPACK_HOME=/tmp/corepack pnpm check`\n- `COREPACK_HOME=/tmp/corepack pnpm check-types`\n- `COREPACK_HOME=/tmp/corepack pnpm vitest run`\n- `COREPACK_HOME=/tmp/corepack pnpm build`