### PR TITLE
fix: send stripe billing lifecycle emails

### DIFF
--- a/editor/src/__tests__/email/billing-lifecycle-emails.test.ts
+++ b/editor/src/__tests__/email/billing-lifecycle-emails.test.ts
@@ -1,363 +1,364 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockEmailsSend, mockResend, mockPrisma, mockStripe } = vi.hoisted(
-	() => ({
-		mockEmailsSend: vi.fn(),
-		mockResend: vi.fn(function MockResend() {
-			return {
-				emails: {
-					send: mockEmailsSend,
-				},
-			};
-		}),
-		mockPrisma: {
-			$transaction: vi.fn(),
-			organization: {
-				findUnique: vi.fn(),
-				update: vi.fn(),
-			},
-			member: {
-				findFirst: vi.fn(),
-			},
-			subscription: {
-				upsert: vi.fn(),
-				updateMany: vi.fn(),
-			},
-			creditTransaction: {
-				create: vi.fn(),
-			},
-			billingHistory: {
-				create: vi.fn(),
-			},
-		},
-		mockStripe: {
-			subscriptions: {
-				retrieve: vi.fn(),
-			},
-		},
-	}),
+  () => ({
+    mockEmailsSend: vi.fn(),
+    mockResend: vi.fn(function MockResend() {
+      return {
+        emails: {
+          send: mockEmailsSend,
+        },
+      };
+    }),
+    mockPrisma: {
+      $transaction: vi.fn(),
+      organization: {
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+      member: {
+        findFirst: vi.fn(),
+      },
+      subscription: {
+        upsert: vi.fn(),
+        updateMany: vi.fn(),
+      },
+      creditTransaction: {
+        create: vi.fn(),
+      },
+      billingHistory: {
+        create: vi.fn(),
+      },
+    },
+    mockStripe: {
+      subscriptions: {
+        retrieve: vi.fn(),
+      },
+    },
+  })
 );
 
-vi.mock("resend", () => ({
-	Resend: mockResend,
+vi.mock('resend', () => ({
+  Resend: mockResend,
 }));
 
-vi.mock("@/lib/db", () => ({
-	prisma: mockPrisma,
+vi.mock('@/lib/db', () => ({
+  prisma: mockPrisma,
 }));
 
-vi.mock("@/lib/stripe", () => ({
-	stripe: mockStripe,
+vi.mock('@/lib/stripe', () => ({
+  stripe: mockStripe,
 }));
 
 import {
-	handleCheckoutComplete,
-	handleInvoicePaid,
-	handleSubscriptionUpdated,
-} from "@/lib/stripe-handlers";
+  handleCheckoutComplete,
+  handleInvoicePaid,
+  handleSubscriptionUpdated,
+} from '@/lib/stripe-handlers';
 
-describe("Stripe billing lifecycle emails", () => {
-	beforeEach(async () => {
-		vi.clearAllMocks();
-		process.env.RESEND_API_KEY = "test-resend-key";
-		delete process.env.RESEND_FROM_EMAIL;
-		process.env.NEXT_PUBLIC_APP_URL = "https://vizora.dev";
-		process.env.STRIPE_PRO_PRICE_ID = "price_pro";
+describe('Stripe billing lifecycle emails', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.RESEND_API_KEY = 'test-resend-key';
+    delete process.env.RESEND_FROM_EMAIL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://vizora.dev';
+    process.env.STRIPE_PRO_PRICE_ID = 'price_pro';
 
-		mockPrisma.$transaction.mockImplementation(
-			async (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma),
-		);
-		mockPrisma.organization.update.mockResolvedValue({ id: "org-1" });
-		mockPrisma.subscription.upsert.mockResolvedValue({ id: "sub-db-1" });
-		mockPrisma.subscription.updateMany.mockResolvedValue({ count: 1 });
-		mockPrisma.creditTransaction.create.mockResolvedValue({ id: "ct-1" });
-		mockPrisma.billingHistory.create.mockResolvedValue({ id: "bh-1" });
-		mockPrisma.member.findFirst.mockResolvedValue({
-			user: {
-				email: "owner@vizora.dev",
-				name: "Owner",
-			},
-		});
-		mockStripe.subscriptions.retrieve.mockResolvedValue({
-			id: "sub_123",
-			current_period_end: 1770000000,
-			items: {
-				data: [
-					{
-						price: {
-							id: "price_pro",
-						},
-					},
-				],
-			},
-		});
+    mockPrisma.$transaction.mockImplementation(
+      async (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma)
+    );
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.subscription.upsert.mockResolvedValue({ id: 'sub-db-1' });
+    mockPrisma.subscription.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.creditTransaction.create.mockResolvedValue({ id: 'ct-1' });
+    mockPrisma.billingHistory.create.mockResolvedValue({ id: 'bh-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
+    });
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_123',
+      current_period_end: 1770000000,
+      items: {
+        data: [
+          {
+            price: {
+              id: 'price_pro',
+            },
+          },
+        ],
+      },
+    });
 
-		await Promise.resolve();
-		await Promise.resolve();
-	});
+    await Promise.resolve();
+    await Promise.resolve();
+  });
 
-	afterEach(() => {
-		delete process.env.RESEND_API_KEY;
-		delete process.env.RESEND_FROM_EMAIL;
-		delete process.env.NEXT_PUBLIC_APP_URL;
-		delete process.env.STRIPE_PRO_PRICE_ID;
-	});
+  afterEach(() => {
+    delete process.env.RESEND_API_KEY;
+    delete process.env.RESEND_FROM_EMAIL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.STRIPE_PRO_PRICE_ID;
+  });
 
-	it("sends a credit pack purchase confirmation with pack size, amount paid, new balance, and billing link", async () => {
-		// CODER NOTE: This test expects the payment-mode checkout flow to email only after
-		// the transaction succeeds, using the committed new balance in the email body.
-		mockPrisma.organization.findUnique.mockResolvedValue({
-			id: "org-1",
-			creditBalance: 500,
-			monthlyAllotment: 1000,
-		});
+  it('sends a credit pack purchase confirmation with pack size, amount paid, new balance, and billing link', async () => {
+    // CODER NOTE: This test expects the payment-mode checkout flow to email only after
+    // the transaction succeeds, using the committed new balance in the email body.
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      creditBalance: 500,
+      monthlyAllotment: 1000,
+    });
 
-		await handleCheckoutComplete({
-			data: {
-				object: {
-					id: "cs_payment_123",
-					mode: "payment",
-					amount_total: 499,
-					metadata: {
-						organizationId: "org-1",
-						packSize: "500",
-					},
-				},
-			},
-		} as never);
+    await handleCheckoutComplete({
+      data: {
+        object: {
+          id: 'cs_payment_123',
+          mode: 'payment',
+          amount_total: 499,
+          metadata: {
+            organizationId: 'org-1',
+            packSize: '500',
+          },
+        },
+      },
+    } as never);
 
-		expect(mockEmailsSend).toHaveBeenCalledTimes(1);
-		const payload = mockEmailsSend.mock.calls[0]?.[0];
-		expect(payload.to).toBe("owner@vizora.dev");
-		expect(payload.from).toBe("noreply@vizora.dev");
-		expect(payload.subject).toMatch(/purchase|credits|confirmation/i);
-		expect(payload.text).toContain("500");
-		expect(payload.text).toContain("4.99");
-		expect(payload.text).toContain("1000");
-		expect(payload.text).toContain("/dashboard/billing");
-	});
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.to).toBe('owner@vizora.dev');
+    expect(payload.from).toBe('noreply@vizora.dev');
+    expect(payload.subject).toMatch(/purchase|credits|confirmation/i);
+    expect(payload.text).toContain('500');
+    expect(payload.text).toContain('4.99');
+    expect(payload.text).toContain('1000');
+    expect(payload.text).toContain('/dashboard/billing');
+  });
 
-	it("sends a subscription welcome email with tier name, monthly allotment, next billing date, and billing link", async () => {
-		// CODER NOTE: This test expects the subscription-mode checkout flow to resolve the
-		// subscription tier from Stripe and include the period-end date in plain text.
-		mockPrisma.organization.findUnique.mockResolvedValue({
-			id: "org-1",
-			creditBalance: 0,
-		});
+  it('sends a subscription welcome email with tier name, monthly allotment, next billing date, and billing link', async () => {
+    // CODER NOTE: This test expects the subscription-mode checkout flow to resolve the
+    // subscription tier from Stripe and include the period-end date in plain text.
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      creditBalance: 0,
+    });
 
-		await handleCheckoutComplete({
-			data: {
-				object: {
-					id: "cs_sub_123",
-					mode: "subscription",
-					customer: "cus_123",
-					subscription: "sub_123",
-					metadata: {
-						organizationId: "org-1",
-					},
-				},
-			},
-		} as never);
+    await handleCheckoutComplete({
+      data: {
+        object: {
+          id: 'cs_sub_123',
+          mode: 'subscription',
+          customer: 'cus_123',
+          subscription: 'sub_123',
+          metadata: {
+            organizationId: 'org-1',
+          },
+        },
+      },
+    } as never);
 
-		expect(mockEmailsSend).toHaveBeenCalledTimes(1);
-		const payload = mockEmailsSend.mock.calls[0]?.[0];
-		expect(payload.to).toBe("owner@vizora.dev");
-		expect(payload.from).toBe("noreply@vizora.dev");
-		expect(payload.subject).toMatch(/welcome|subscription/i);
-		expect(payload.text).toMatch(/pro|tier/i);
-		expect(payload.text).toMatch(/1000|monthly allotment/i);
-		expect(payload.text).toContain("/dashboard/billing");
-	});
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.to).toBe('owner@vizora.dev');
+    expect(payload.from).toBe('noreply@vizora.dev');
+    expect(payload.subject).toMatch(/welcome|subscription/i);
+    expect(payload.text).toMatch(/pro|tier/i);
+    expect(payload.text).toMatch(/1000|monthly allotment/i);
+    expect(payload.text).toContain('/dashboard/billing');
+  });
 
-	it("sends a cancellation confirmation with cancellation date, free-tier note, and billing link", async () => {
-		await handleSubscriptionUpdated({
-			data: {
-				object: {
-					id: "sub_123",
-					customer: "cus_123",
-					status: "active",
-					cancel_at_period_end: true,
-					cancel_at: null,
-					current_period_end: 1770000000,
-					items: {
-						data: [
-							{
-								price: {
-									id: "price_pro",
-								},
-							},
-						],
-					},
-					metadata: {
-						organizationId: "org-1",
-					},
-				},
-			},
-		} as never);
+  it('sends a cancellation confirmation with cancellation date, free-tier note, and billing link', async () => {
+    await handleSubscriptionUpdated({
+      data: {
+        object: {
+          id: 'sub_123',
+          customer: 'cus_123',
+          status: 'active',
+          cancel_at_period_end: true,
+          cancel_at: null,
+          current_period_end: 1770000000,
+          items: {
+            data: [
+              {
+                price: {
+                  id: 'price_pro',
+                },
+              },
+            ],
+          },
+          metadata: {
+            organizationId: 'org-1',
+          },
+        },
+      },
+    } as never);
 
-		expect(mockEmailsSend).toHaveBeenCalledTimes(1);
-		const payload = mockEmailsSend.mock.calls[0]?.[0];
-		expect(payload.subject).toMatch(/cancel/i);
-		expect(payload.text).toMatch(/free tier|free plan/i);
-		expect(payload.text).toContain("/dashboard/billing");
-	});
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.subject).toMatch(/cancel/i);
+    expect(payload.text).toMatch(/free tier|free plan/i);
+    expect(payload.text).toContain('/dashboard/billing');
+  });
 
-	it("does not send a cancellation email when the subscription is not cancelling", async () => {
-		await handleSubscriptionUpdated({
-			data: {
-				object: {
-					id: "sub_123",
-					customer: "cus_123",
-					status: "active",
-					cancel_at_period_end: false,
-					cancel_at: null,
-					current_period_end: 1770000000,
-					items: {
-						data: [
-							{
-								price: {
-									id: "price_pro",
-								},
-							},
-						],
-					},
-					metadata: {
-						organizationId: "org-1",
-					},
-				},
-			},
-		} as never);
+  it('does not send a cancellation email when the subscription is not cancelling', async () => {
+    await handleSubscriptionUpdated({
+      data: {
+        object: {
+          id: 'sub_123',
+          customer: 'cus_123',
+          status: 'active',
+          cancel_at_period_end: false,
+          cancel_at: null,
+          current_period_end: 1770000000,
+          items: {
+            data: [
+              {
+                price: {
+                  id: 'price_pro',
+                },
+              },
+            ],
+          },
+          metadata: {
+            organizationId: 'org-1',
+          },
+        },
+      },
+    } as never);
 
-		expect(mockEmailsSend).not.toHaveBeenCalled();
-	});
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
 
-	it("sends a renewal receipt with credits added, new balance, next renewal date, and billing link", async () => {
-		mockPrisma.organization.findUnique.mockResolvedValue({
-			id: "org-1",
-			name: "Vizora Studio",
-			tier: "pro",
-			creditBalance: 250,
-		});
+  it('sends a renewal receipt with credits added, new balance, next renewal date, and billing link', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      name: 'Vizora Studio',
+      tier: 'pro',
+      creditBalance: 250,
+      monthlyAllotment: 1000,
+    });
 
-		await handleInvoicePaid({
-			data: {
-				object: {
-					id: "in_paid_123",
-					customer: "cus_123",
-					billing_reason: "subscription_cycle",
-					subscription: "sub_123",
-				},
-			},
-		} as never);
+    await handleInvoicePaid({
+      data: {
+        object: {
+          id: 'in_paid_123',
+          customer: 'cus_123',
+          billing_reason: 'subscription_cycle',
+          subscription: 'sub_123',
+        },
+      },
+    } as never);
 
-		expect(mockEmailsSend).toHaveBeenCalledTimes(1);
-		const payload = mockEmailsSend.mock.calls[0]?.[0];
-		expect(payload.subject).toMatch(/receipt|renewal|invoice/i);
-		expect(payload.text).toMatch(/credits added|credits/i);
-		expect(payload.text).toContain("/dashboard/billing");
-	});
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.subject).toMatch(/receipt|renewal|invoice/i);
+    expect(payload.text).toMatch(/credits added|credits/i);
+    expect(payload.text).toContain('/dashboard/billing');
+  });
 
-	it("does not send a renewal email for subscription_create invoices", async () => {
-		mockPrisma.organization.findUnique.mockResolvedValue({
-			id: "org-1",
-			name: "Vizora Studio",
-			tier: "pro",
-			creditBalance: 250,
-		});
+  it('does not send a renewal email for subscription_create invoices', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      name: 'Vizora Studio',
+      tier: 'pro',
+      creditBalance: 250,
+    });
 
-		await handleInvoicePaid({
-			data: {
-				object: {
-					id: "in_create_123",
-					customer: "cus_123",
-					billing_reason: "subscription_create",
-					subscription: "sub_123",
-				},
-			},
-		} as never);
+    await handleInvoicePaid({
+      data: {
+        object: {
+          id: 'in_create_123',
+          customer: 'cus_123',
+          billing_reason: 'subscription_create',
+          subscription: 'sub_123',
+        },
+      },
+    } as never);
 
-		expect(mockEmailsSend).not.toHaveBeenCalled();
-	});
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
 
-	it("uses the RESEND_FROM_EMAIL env var when set", async () => {
-		process.env.RESEND_FROM_EMAIL = "billing@vizora.dev";
-		mockPrisma.organization.findUnique.mockResolvedValue({
-			id: "org-1",
-			creditBalance: 500,
-			monthlyAllotment: 1000,
-		});
+  it('uses the RESEND_FROM_EMAIL env var when set', async () => {
+    process.env.RESEND_FROM_EMAIL = 'billing@vizora.dev';
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      creditBalance: 500,
+      monthlyAllotment: 1000,
+    });
 
-		await handleCheckoutComplete({
-			data: {
-				object: {
-					id: "cs_payment_456",
-					mode: "payment",
-					amount_total: 999,
-					metadata: {
-						organizationId: "org-1",
-						packSize: "1000",
-					},
-				},
-			},
-		} as never);
+    await handleCheckoutComplete({
+      data: {
+        object: {
+          id: 'cs_payment_456',
+          mode: 'payment',
+          amount_total: 999,
+          metadata: {
+            organizationId: 'org-1',
+            packSize: '1000',
+          },
+        },
+      },
+    } as never);
 
-		const payload = mockEmailsSend.mock.calls[0]?.[0];
-		expect(payload.from).toBe("billing@vizora.dev");
-	});
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.from).toBe('billing@vizora.dev');
+  });
 
-	it("does not send the new lifecycle email when no owner is found", async () => {
-		mockPrisma.member.findFirst.mockResolvedValue(null);
-		mockPrisma.organization.findUnique.mockResolvedValue({
-			id: "org-1",
-			creditBalance: 500,
-			monthlyAllotment: 1000,
-		});
+  it('does not send the new lifecycle email when no owner is found', async () => {
+    mockPrisma.member.findFirst.mockResolvedValue(null);
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      creditBalance: 500,
+      monthlyAllotment: 1000,
+    });
 
-		await handleCheckoutComplete({
-			data: {
-				object: {
-					id: "cs_payment_789",
-					mode: "payment",
-					amount_total: 499,
-					metadata: {
-						organizationId: "org-1",
-						packSize: "500",
-					},
-				},
-			},
-		} as never);
+    await handleCheckoutComplete({
+      data: {
+        object: {
+          id: 'cs_payment_789',
+          mode: 'payment',
+          amount_total: 499,
+          metadata: {
+            organizationId: 'org-1',
+            packSize: '500',
+          },
+        },
+      },
+    } as never);
 
-		expect(mockEmailsSend).not.toHaveBeenCalled();
-	});
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
 
-	it("does not send the new lifecycle email when Resend is unavailable", async () => {
-		delete process.env.RESEND_API_KEY;
+  it('does not send the new lifecycle email when Resend is unavailable', async () => {
+    delete process.env.RESEND_API_KEY;
 
-		await handleSubscriptionUpdated({
-			data: {
-				object: {
-					id: "sub_999",
-					customer: "cus_999",
-					status: "active",
-					cancel_at_period_end: true,
-					cancel_at: null,
-					current_period_end: 1770000000,
-					items: {
-						data: [
-							{
-								price: {
-									id: "price_pro",
-								},
-							},
-						],
-					},
-					metadata: {
-						organizationId: "org-1",
-					},
-				},
-			},
-		} as never);
+    await handleSubscriptionUpdated({
+      data: {
+        object: {
+          id: 'sub_999',
+          customer: 'cus_999',
+          status: 'active',
+          cancel_at_period_end: true,
+          cancel_at: null,
+          current_period_end: 1770000000,
+          items: {
+            data: [
+              {
+                price: {
+                  id: 'price_pro',
+                },
+              },
+            ],
+          },
+          metadata: {
+            organizationId: 'org-1',
+          },
+        },
+      },
+    } as never);
 
-		expect(mockEmailsSend).not.toHaveBeenCalled();
-	});
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
 });

--- a/editor/src/__tests__/email/billing-lifecycle-emails.test.ts
+++ b/editor/src/__tests__/email/billing-lifecycle-emails.test.ts
@@ -1,0 +1,363 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEmailsSend, mockResend, mockPrisma, mockStripe } = vi.hoisted(
+	() => ({
+		mockEmailsSend: vi.fn(),
+		mockResend: vi.fn(function MockResend() {
+			return {
+				emails: {
+					send: mockEmailsSend,
+				},
+			};
+		}),
+		mockPrisma: {
+			$transaction: vi.fn(),
+			organization: {
+				findUnique: vi.fn(),
+				update: vi.fn(),
+			},
+			member: {
+				findFirst: vi.fn(),
+			},
+			subscription: {
+				upsert: vi.fn(),
+				updateMany: vi.fn(),
+			},
+			creditTransaction: {
+				create: vi.fn(),
+			},
+			billingHistory: {
+				create: vi.fn(),
+			},
+		},
+		mockStripe: {
+			subscriptions: {
+				retrieve: vi.fn(),
+			},
+		},
+	}),
+);
+
+vi.mock("resend", () => ({
+	Resend: mockResend,
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: mockPrisma,
+}));
+
+vi.mock("@/lib/stripe", () => ({
+	stripe: mockStripe,
+}));
+
+import {
+	handleCheckoutComplete,
+	handleInvoicePaid,
+	handleSubscriptionUpdated,
+} from "@/lib/stripe-handlers";
+
+describe("Stripe billing lifecycle emails", () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		process.env.RESEND_API_KEY = "test-resend-key";
+		delete process.env.RESEND_FROM_EMAIL;
+		process.env.NEXT_PUBLIC_APP_URL = "https://vizora.dev";
+		process.env.STRIPE_PRO_PRICE_ID = "price_pro";
+
+		mockPrisma.$transaction.mockImplementation(
+			async (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma),
+		);
+		mockPrisma.organization.update.mockResolvedValue({ id: "org-1" });
+		mockPrisma.subscription.upsert.mockResolvedValue({ id: "sub-db-1" });
+		mockPrisma.subscription.updateMany.mockResolvedValue({ count: 1 });
+		mockPrisma.creditTransaction.create.mockResolvedValue({ id: "ct-1" });
+		mockPrisma.billingHistory.create.mockResolvedValue({ id: "bh-1" });
+		mockPrisma.member.findFirst.mockResolvedValue({
+			user: {
+				email: "owner@vizora.dev",
+				name: "Owner",
+			},
+		});
+		mockStripe.subscriptions.retrieve.mockResolvedValue({
+			id: "sub_123",
+			current_period_end: 1770000000,
+			items: {
+				data: [
+					{
+						price: {
+							id: "price_pro",
+						},
+					},
+				],
+			},
+		});
+
+		await Promise.resolve();
+		await Promise.resolve();
+	});
+
+	afterEach(() => {
+		delete process.env.RESEND_API_KEY;
+		delete process.env.RESEND_FROM_EMAIL;
+		delete process.env.NEXT_PUBLIC_APP_URL;
+		delete process.env.STRIPE_PRO_PRICE_ID;
+	});
+
+	it("sends a credit pack purchase confirmation with pack size, amount paid, new balance, and billing link", async () => {
+		// CODER NOTE: This test expects the payment-mode checkout flow to email only after
+		// the transaction succeeds, using the committed new balance in the email body.
+		mockPrisma.organization.findUnique.mockResolvedValue({
+			id: "org-1",
+			creditBalance: 500,
+			monthlyAllotment: 1000,
+		});
+
+		await handleCheckoutComplete({
+			data: {
+				object: {
+					id: "cs_payment_123",
+					mode: "payment",
+					amount_total: 499,
+					metadata: {
+						organizationId: "org-1",
+						packSize: "500",
+					},
+				},
+			},
+		} as never);
+
+		expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+		const payload = mockEmailsSend.mock.calls[0]?.[0];
+		expect(payload.to).toBe("owner@vizora.dev");
+		expect(payload.from).toBe("noreply@vizora.dev");
+		expect(payload.subject).toMatch(/purchase|credits|confirmation/i);
+		expect(payload.text).toContain("500");
+		expect(payload.text).toContain("4.99");
+		expect(payload.text).toContain("1000");
+		expect(payload.text).toContain("/dashboard/billing");
+	});
+
+	it("sends a subscription welcome email with tier name, monthly allotment, next billing date, and billing link", async () => {
+		// CODER NOTE: This test expects the subscription-mode checkout flow to resolve the
+		// subscription tier from Stripe and include the period-end date in plain text.
+		mockPrisma.organization.findUnique.mockResolvedValue({
+			id: "org-1",
+			creditBalance: 0,
+		});
+
+		await handleCheckoutComplete({
+			data: {
+				object: {
+					id: "cs_sub_123",
+					mode: "subscription",
+					customer: "cus_123",
+					subscription: "sub_123",
+					metadata: {
+						organizationId: "org-1",
+					},
+				},
+			},
+		} as never);
+
+		expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+		const payload = mockEmailsSend.mock.calls[0]?.[0];
+		expect(payload.to).toBe("owner@vizora.dev");
+		expect(payload.from).toBe("noreply@vizora.dev");
+		expect(payload.subject).toMatch(/welcome|subscription/i);
+		expect(payload.text).toMatch(/pro|tier/i);
+		expect(payload.text).toMatch(/1000|monthly allotment/i);
+		expect(payload.text).toContain("/dashboard/billing");
+	});
+
+	it("sends a cancellation confirmation with cancellation date, free-tier note, and billing link", async () => {
+		await handleSubscriptionUpdated({
+			data: {
+				object: {
+					id: "sub_123",
+					customer: "cus_123",
+					status: "active",
+					cancel_at_period_end: true,
+					cancel_at: null,
+					current_period_end: 1770000000,
+					items: {
+						data: [
+							{
+								price: {
+									id: "price_pro",
+								},
+							},
+						],
+					},
+					metadata: {
+						organizationId: "org-1",
+					},
+				},
+			},
+		} as never);
+
+		expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+		const payload = mockEmailsSend.mock.calls[0]?.[0];
+		expect(payload.subject).toMatch(/cancel/i);
+		expect(payload.text).toMatch(/free tier|free plan/i);
+		expect(payload.text).toContain("/dashboard/billing");
+	});
+
+	it("does not send a cancellation email when the subscription is not cancelling", async () => {
+		await handleSubscriptionUpdated({
+			data: {
+				object: {
+					id: "sub_123",
+					customer: "cus_123",
+					status: "active",
+					cancel_at_period_end: false,
+					cancel_at: null,
+					current_period_end: 1770000000,
+					items: {
+						data: [
+							{
+								price: {
+									id: "price_pro",
+								},
+							},
+						],
+					},
+					metadata: {
+						organizationId: "org-1",
+					},
+				},
+			},
+		} as never);
+
+		expect(mockEmailsSend).not.toHaveBeenCalled();
+	});
+
+	it("sends a renewal receipt with credits added, new balance, next renewal date, and billing link", async () => {
+		mockPrisma.organization.findUnique.mockResolvedValue({
+			id: "org-1",
+			name: "Vizora Studio",
+			tier: "pro",
+			creditBalance: 250,
+		});
+
+		await handleInvoicePaid({
+			data: {
+				object: {
+					id: "in_paid_123",
+					customer: "cus_123",
+					billing_reason: "subscription_cycle",
+					subscription: "sub_123",
+				},
+			},
+		} as never);
+
+		expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+		const payload = mockEmailsSend.mock.calls[0]?.[0];
+		expect(payload.subject).toMatch(/receipt|renewal|invoice/i);
+		expect(payload.text).toMatch(/credits added|credits/i);
+		expect(payload.text).toContain("/dashboard/billing");
+	});
+
+	it("does not send a renewal email for subscription_create invoices", async () => {
+		mockPrisma.organization.findUnique.mockResolvedValue({
+			id: "org-1",
+			name: "Vizora Studio",
+			tier: "pro",
+			creditBalance: 250,
+		});
+
+		await handleInvoicePaid({
+			data: {
+				object: {
+					id: "in_create_123",
+					customer: "cus_123",
+					billing_reason: "subscription_create",
+					subscription: "sub_123",
+				},
+			},
+		} as never);
+
+		expect(mockEmailsSend).not.toHaveBeenCalled();
+	});
+
+	it("uses the RESEND_FROM_EMAIL env var when set", async () => {
+		process.env.RESEND_FROM_EMAIL = "billing@vizora.dev";
+		mockPrisma.organization.findUnique.mockResolvedValue({
+			id: "org-1",
+			creditBalance: 500,
+			monthlyAllotment: 1000,
+		});
+
+		await handleCheckoutComplete({
+			data: {
+				object: {
+					id: "cs_payment_456",
+					mode: "payment",
+					amount_total: 999,
+					metadata: {
+						organizationId: "org-1",
+						packSize: "1000",
+					},
+				},
+			},
+		} as never);
+
+		const payload = mockEmailsSend.mock.calls[0]?.[0];
+		expect(payload.from).toBe("billing@vizora.dev");
+	});
+
+	it("does not send the new lifecycle email when no owner is found", async () => {
+		mockPrisma.member.findFirst.mockResolvedValue(null);
+		mockPrisma.organization.findUnique.mockResolvedValue({
+			id: "org-1",
+			creditBalance: 500,
+			monthlyAllotment: 1000,
+		});
+
+		await handleCheckoutComplete({
+			data: {
+				object: {
+					id: "cs_payment_789",
+					mode: "payment",
+					amount_total: 499,
+					metadata: {
+						organizationId: "org-1",
+						packSize: "500",
+					},
+				},
+			},
+		} as never);
+
+		expect(mockEmailsSend).not.toHaveBeenCalled();
+	});
+
+	it("does not send the new lifecycle email when Resend is unavailable", async () => {
+		delete process.env.RESEND_API_KEY;
+
+		await handleSubscriptionUpdated({
+			data: {
+				object: {
+					id: "sub_999",
+					customer: "cus_999",
+					status: "active",
+					cancel_at_period_end: true,
+					cancel_at: null,
+					current_period_end: 1770000000,
+					items: {
+						data: [
+							{
+								price: {
+									id: "price_pro",
+								},
+							},
+						],
+					},
+					metadata: {
+						organizationId: "org-1",
+					},
+				},
+			},
+		} as never);
+
+		expect(mockEmailsSend).not.toHaveBeenCalled();
+	});
+});

--- a/editor/src/__tests__/email/stripe-emails.test.ts
+++ b/editor/src/__tests__/email/stripe-emails.test.ts
@@ -1,33 +1,35 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockEmailsSend, mockResend, mockPrisma, mockStripe } = vi.hoisted(() => ({
-  mockEmailsSend: vi.fn(),
-  mockResend: vi.fn(function MockResend() {
-    return {
-      emails: {
-        send: mockEmailsSend,
+const { mockEmailsSend, mockResend, mockPrisma, mockStripe } = vi.hoisted(
+  () => ({
+    mockEmailsSend: vi.fn(),
+    mockResend: vi.fn(function MockResend() {
+      return {
+        emails: {
+          send: mockEmailsSend,
+        },
+      };
+    }),
+    mockPrisma: {
+      organization: {
+        findUnique: vi.fn(),
+        update: vi.fn(),
       },
-    };
-  }),
-  mockPrisma: {
-    organization: {
-      findUnique: vi.fn(),
-      update: vi.fn(),
+      member: {
+        findFirst: vi.fn(),
+      },
+      creditTransaction: {
+        create: vi.fn(),
+      },
+      $transaction: vi.fn(),
     },
-    member: {
-      findFirst: vi.fn(),
+    mockStripe: {
+      subscriptions: {
+        retrieve: vi.fn(),
+      },
     },
-    creditTransaction: {
-      create: vi.fn(),
-    },
-    $transaction: vi.fn(),
-  },
-  mockStripe: {
-    subscriptions: {
-      retrieve: vi.fn(),
-    },
-  },
-}));
+  })
+);
 
 vi.mock('resend', () => ({
   Resend: mockResend,
@@ -56,7 +58,9 @@ describe('Billing email flows', () => {
     process.env.NEXT_PUBLIC_APP_URL = 'https://vizora.dev';
     process.env.STRIPE_PRO_PRICE_ID = 'price_pro';
 
-    mockPrisma.$transaction.mockImplementation(async (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma));
+    mockPrisma.$transaction.mockImplementation(
+      async (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma)
+    );
     mockPrisma.creditTransaction.create.mockResolvedValue({ id: 'ct_1' });
     mockStripe.subscriptions.retrieve.mockResolvedValue({
       id: 'sub_123',
@@ -235,6 +239,7 @@ describe('Billing email flows', () => {
       data: {
         object: {
           id: 'sub_123',
+          customer: 'cus_123',
           cancel_at_period_end: true,
           cancel_at: null,
           current_period_end: 1770000000,
@@ -275,6 +280,7 @@ describe('Billing email flows', () => {
       data: {
         object: {
           id: 'sub_123',
+          customer: 'cus_123',
           cancel_at_period_end: false,
           cancel_at: null,
           current_period_end: 1770000000,

--- a/editor/src/__tests__/email/stripe-emails.test.ts
+++ b/editor/src/__tests__/email/stripe-emails.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockEmailsSend, mockResend, mockPrisma } = vi.hoisted(() => ({
+const { mockEmailsSend, mockResend, mockPrisma, mockStripe } = vi.hoisted(() => ({
   mockEmailsSend: vi.fn(),
   mockResend: vi.fn(function MockResend() {
     return {
@@ -17,6 +17,15 @@ const { mockEmailsSend, mockResend, mockPrisma } = vi.hoisted(() => ({
     member: {
       findFirst: vi.fn(),
     },
+    creditTransaction: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+  mockStripe: {
+    subscriptions: {
+      retrieve: vi.fn(),
+    },
   },
 }));
 
@@ -28,13 +37,34 @@ vi.mock('@/lib/db', () => ({
   prisma: mockPrisma,
 }));
 
-import { handlePaymentFailed } from '@/lib/stripe-handlers';
+vi.mock('@/lib/stripe', () => ({
+  stripe: mockStripe,
+}));
+
+import {
+  handleCheckoutComplete,
+  handleInvoicePaid,
+  handlePaymentFailed,
+  handleSubscriptionUpdated,
+} from '@/lib/stripe-handlers';
 
 describe('Billing email flows', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     process.env.RESEND_API_KEY = 'test-resend-key';
     delete process.env.RESEND_FROM_EMAIL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://vizora.dev';
+    process.env.STRIPE_PRO_PRICE_ID = 'price_pro';
+
+    mockPrisma.$transaction.mockImplementation(async (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma));
+    mockPrisma.creditTransaction.create.mockResolvedValue({ id: 'ct_1' });
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_123',
+      items: {
+        data: [{ price: { id: 'price_pro' } }],
+      },
+    });
+
     await Promise.resolve();
     await Promise.resolve();
   });
@@ -108,6 +138,286 @@ describe('Billing email flows', () => {
         object: {
           id: 'in_789',
           customer: 'cus_789',
+        },
+      },
+    } as never);
+
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
+
+  it('should send a credit pack purchase email with correct payload', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      creditBalance: 500,
+      monthlyAllotment: 1000,
+      name: 'Vizora Studio',
+    });
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
+    });
+
+    await handleCheckoutComplete({
+      data: {
+        object: {
+          mode: 'payment',
+          amount_total: 499,
+          metadata: {
+            organizationId: 'org-1',
+            packSize: '500',
+          },
+        },
+      },
+    } as never);
+
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.to).toBe('owner@vizora.dev');
+    expect(payload.from).toBe('noreply@vizora.dev');
+    expect(payload.text).toContain('500');
+    expect(payload.text).toContain('4.99');
+    expect(payload.text).toContain('/dashboard/billing');
+  });
+
+  it('should send a subscription created email with tier details and billing link', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      creditBalance: 0,
+      name: 'Vizora Studio',
+    });
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
+    });
+
+    await handleCheckoutComplete({
+      data: {
+        object: {
+          mode: 'subscription',
+          subscription: 'sub_123',
+          metadata: {
+            organizationId: 'org-1',
+          },
+        },
+      },
+    } as never);
+
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.to).toBe('owner@vizora.dev');
+    expect(payload.from).toBe('noreply@vizora.dev');
+    expect(payload.text).toContain('/dashboard/billing');
+    expect(payload.text).toMatch(/pro|tier|monthly/i);
+  });
+
+  it('should send a subscription cancelled email when cancellation is scheduled', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      name: 'Vizora Studio',
+      tier: 'pro',
+      monthlyAllotment: 1000,
+    });
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
+    });
+
+    await handleSubscriptionUpdated({
+      data: {
+        object: {
+          id: 'sub_123',
+          cancel_at_period_end: true,
+          cancel_at: null,
+          current_period_end: 1770000000,
+          metadata: {
+            organizationId: 'org-1',
+          },
+          items: {
+            data: [{ price: { id: 'price_pro' } }],
+          },
+        },
+      },
+    } as never);
+
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.to).toBe('owner@vizora.dev');
+    expect(payload.from).toBe('noreply@vizora.dev');
+    expect(payload.text).toContain('/dashboard/billing');
+    expect(payload.text).toMatch(/free tier|cancel/i);
+  });
+
+  it('should not send a subscription cancelled email when cancellation is not scheduled', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      name: 'Vizora Studio',
+      tier: 'pro',
+      monthlyAllotment: 1000,
+    });
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
+    });
+
+    await handleSubscriptionUpdated({
+      data: {
+        object: {
+          id: 'sub_123',
+          cancel_at_period_end: false,
+          cancel_at: null,
+          current_period_end: 1770000000,
+          metadata: {
+            organizationId: 'org-1',
+          },
+          items: {
+            data: [{ price: { id: 'price_pro' } }],
+          },
+        },
+      },
+    } as never);
+
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
+
+  it('should send an invoice paid renewal email with credits, balance, and billing link', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      name: 'Vizora Studio',
+      tier: 'pro',
+      creditBalance: 100,
+      monthlyAllotment: 1000,
+    });
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
+    });
+
+    await handleInvoicePaid({
+      data: {
+        object: {
+          id: 'in_renew_1',
+          billing_reason: 'subscription_cycle',
+          subscription: 'sub_123',
+          customer: 'cus_123',
+          lines: {
+            data: [{ period: { end: 1770000000 } }],
+          },
+          metadata: {
+            organizationId: 'org-1',
+          },
+        },
+      },
+    } as never);
+
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.to).toBe('owner@vizora.dev');
+    expect(payload.from).toBe('noreply@vizora.dev');
+    expect(payload.text).toContain('/dashboard/billing');
+    expect(payload.text).toMatch(/credit|renew/i);
+  });
+
+  it('should not send an invoice paid renewal email for subscription_create invoices', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      name: 'Vizora Studio',
+      tier: 'pro',
+      creditBalance: 100,
+      monthlyAllotment: 1000,
+    });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
+    });
+
+    await handleInvoicePaid({
+      data: {
+        object: {
+          id: 'in_create_1',
+          billing_reason: 'subscription_create',
+          subscription: 'sub_123',
+          customer: 'cus_123',
+          lines: {
+            data: [{ period: { end: 1770000000 } }],
+          },
+          metadata: {
+            organizationId: 'org-1',
+          },
+        },
+      },
+    } as never);
+
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
+
+  it('should use noreply fallback when RESEND_FROM_EMAIL is unset', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      creditBalance: 500,
+      monthlyAllotment: 1000,
+      name: 'Vizora Studio',
+    });
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue({
+      user: {
+        email: 'owner@vizora.dev',
+        name: 'Owner',
+      },
+    });
+
+    await handleCheckoutComplete({
+      data: {
+        object: {
+          mode: 'payment',
+          amount_total: 499,
+          metadata: {
+            organizationId: 'org-1',
+            packSize: '500',
+          },
+        },
+      },
+    } as never);
+
+    const payload = mockEmailsSend.mock.calls[0]?.[0];
+    expect(payload.from).toBe('noreply@vizora.dev');
+  });
+
+  it('should not send a new billing lifecycle email when owner is not found', async () => {
+    mockPrisma.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      creditBalance: 500,
+      monthlyAllotment: 1000,
+      name: 'Vizora Studio',
+    });
+    mockPrisma.organization.update.mockResolvedValue({ id: 'org-1' });
+    mockPrisma.member.findFirst.mockResolvedValue(null);
+
+    await handleCheckoutComplete({
+      data: {
+        object: {
+          mode: 'payment',
+          amount_total: 499,
+          metadata: {
+            organizationId: 'org-1',
+            packSize: '500',
+          },
         },
       },
     } as never);

--- a/editor/src/lib/stripe-handlers.ts
+++ b/editor/src/lib/stripe-handlers.ts
@@ -15,7 +15,7 @@ async function getResendClient() {
   return new Resend(resendApiKey);
 }
 
-async function findOrganizationOwner(organizationId: string) {
+async function getOrganizationOwnerEmail(organizationId: string) {
   return prisma.member.findFirst({
     where: {
       organizationId,
@@ -26,6 +26,30 @@ async function findOrganizationOwner(organizationId: string) {
         select: { email: true, name: true },
       },
     },
+  });
+}
+
+async function sendBillingLifecycleEmail({
+  organizationId,
+  subject,
+  text,
+}: {
+  organizationId: string;
+  subject: string;
+  text: string;
+}) {
+  const owner = await getOrganizationOwnerEmail(organizationId);
+  const resend = await getResendClient();
+
+  if (!owner || !resend) {
+    return;
+  }
+
+  await resend.emails.send({
+    from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
+    to: owner.user.email,
+    subject,
+    text,
   });
 }
 
@@ -69,6 +93,7 @@ export async function handleCheckoutComplete(event: Stripe.Event) {
     const tierConfig = TIER_CONFIG[tier];
     const now = new Date();
     const cycleEnd = addMonths(now, 1);
+    let newBalance = 0;
 
     // Update organization with subscription details and initial credit grant
     await prisma.$transaction(
@@ -82,7 +107,7 @@ export async function handleCheckoutComplete(event: Stripe.Event) {
           throw new Error(`Organization ${organizationId} not found`);
         }
 
-        const newBalance = org.creditBalance + tierConfig.monthlyAllotment;
+        newBalance = org.creditBalance + tierConfig.monthlyAllotment;
 
         await tx.organization.update({
           where: { id: organizationId },
@@ -127,43 +152,18 @@ export async function handleCheckoutComplete(event: Stripe.Event) {
       }
     );
 
-    const resend = await getResendClient();
-    const owner = await findOrganizationOwner(organizationId);
-
-    if (owner && resend) {
-      try {
-        await resend.emails.send({
-          from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
-          to: owner.user.email,
-          subject: 'Subscription Activated',
-          text: `Hi ${owner.user.name || 'there'},
-
-Welcome to the ${tierConfig.displayName} plan for Vizora.
+    await sendBillingLifecycleEmail({
+      organizationId,
+      subject: `Welcome to Vizora ${tier} subscription`,
+      text: `Your ${tier} tier subscription is now active.
 
 Monthly allotment: ${tierConfig.monthlyAllotment} credits
-Next billing date: ${cycleEnd.toLocaleDateString()}
+Current balance: ${newBalance} credits
+Next billing date: ${cycleEnd.toDateString()}
 
-You can manage your subscription at:
-${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing
-
-Best regards,
-The Vizora Team`,
-        });
-
-        console.log(
-          `[handleCheckoutComplete] Subscription email sent to ${owner.user.email}`
-        );
-      } catch (error) {
-        console.error(
-          '[handleCheckoutComplete] Failed to send subscription email:',
-          error
-        );
-      }
-    } else if (owner && !resend) {
-      console.log(
-        `[handleCheckoutComplete] Would send subscription email to ${owner.user.email} (Resend not configured)`
-      );
-    }
+Manage billing:
+${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing`,
+    });
   }
 
   // Handle credit pack purchase
@@ -221,44 +221,18 @@ The Vizora Team`,
       }
     );
 
-    const resend = await getResendClient();
-    const owner = await findOrganizationOwner(organizationId);
+    await sendBillingLifecycleEmail({
+      organizationId,
+      subject: 'Credits purchase confirmation',
+      text: `Your credit purchase is complete.
 
-    if (owner && resend) {
-      try {
-        await resend.emails.send({
-          from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
-          to: owner.user.email,
-          subject: 'Credit Pack Purchased',
-          text: `Hi ${owner.user.name || 'there'},
-
-Your credit pack purchase was successful.
-
-Pack size: ${packSize} credits
+Credits added: ${packSize}
 Amount paid: ${((session.amount_total || 0) / 100).toFixed(2)}
-New balance: ${newBalance} credits
+New balance: ${newBalance}
 
-View your billing dashboard:
-${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing
-
-Best regards,
-The Vizora Team`,
-        });
-
-        console.log(
-          `[handleCheckoutComplete] Credit pack email sent to ${owner.user.email}`
-        );
-      } catch (error) {
-        console.error(
-          '[handleCheckoutComplete] Failed to send credit pack email:',
-          error
-        );
-      }
-    } else if (owner && !resend) {
-      console.log(
-        `[handleCheckoutComplete] Would send credit pack email to ${owner.user.email} (Resend not configured)`
-      );
-    }
+Manage billing:
+${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing`,
+    });
   }
 }
 
@@ -285,7 +259,6 @@ export async function handleInvoicePaid(event: Stripe.Event) {
     where: { stripeCustomerId: customerId },
     select: {
       id: true,
-      name: true,
       creditBalance: true,
       monthlyAllotment: true,
       tier: true,
@@ -303,9 +276,9 @@ export async function handleInvoicePaid(event: Stripe.Event) {
     `[handleInvoicePaid] Processing invoice ${invoice.id} for org ${org.id}`
   );
 
+  let newBalance = org.creditBalance;
   let addedCredits = 0;
-  let newBalance = 0;
-  let cycleEnd = addMonths(new Date(), 1);
+  const cycleEnd = addMonths(new Date(), 1);
 
   // Perform credit rollover with 2x cap
   await prisma.$transaction(
@@ -318,7 +291,6 @@ export async function handleInvoicePaid(event: Stripe.Event) {
       addedCredits = newBalance - org.creditBalance;
 
       const now = new Date();
-      cycleEnd = addMonths(now, 1);
 
       await tx.organization.update({
         where: { id: org.id },
@@ -357,39 +329,18 @@ export async function handleInvoicePaid(event: Stripe.Event) {
     }
   );
 
-  const resend = await getResendClient();
-  const owner = await findOrganizationOwner(org.id);
-
-  if (owner && resend) {
-    try {
-      await resend.emails.send({
-        from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
-        to: owner.user.email,
-        subject: 'Invoice Renewal Receipt',
-        text: `Hi ${owner.user.name || 'there'},
-
-Your ${org.name} subscription has been renewed successfully.
+  await sendBillingLifecycleEmail({
+    organizationId: org.id,
+    subject: 'Subscription renewal receipt',
+    text: `Your subscription has renewed successfully.
 
 Credits added: ${addedCredits}
-New balance: ${newBalance} credits
-Next renewal date: ${cycleEnd.toLocaleDateString()}
+New balance: ${newBalance}
+Next renewal date: ${cycleEnd.toDateString()}
 
-Manage billing here:
-${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing
-
-Best regards,
-The Vizora Team`,
-      });
-
-      console.log(`[handleInvoicePaid] Email sent to ${owner.user.email}`);
-    } catch (error) {
-      console.error('[handleInvoicePaid] Failed to send email:', error);
-    }
-  } else if (owner && !resend) {
-    console.log(
-      `[handleInvoicePaid] Would send email to ${owner.user.email} (Resend not configured)`
-    );
-  }
+Manage billing:
+${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing`,
+  });
 }
 
 export async function handlePaymentFailed(event: Stripe.Event) {
@@ -432,7 +383,17 @@ export async function handlePaymentFailed(event: Stripe.Event) {
   const resend = await getResendClient();
 
   // Send email notification to organization owner
-  const owner = await findOrganizationOwner(org.id);
+  const owner = await prisma.member.findFirst({
+    where: {
+      organizationId: org.id,
+      role: 'owner',
+    },
+    include: {
+      user: {
+        select: { email: true, name: true },
+      },
+    },
+  });
 
   if (owner && resend) {
     try {
@@ -479,7 +440,7 @@ export async function handleSubscriptionUpdated(event: Stripe.Event) {
 
   const org = await prisma.organization.findUnique({
     where: { stripeCustomerId: customerId },
-    select: { id: true, name: true, tier: true, monthlyAllotment: true },
+    select: { id: true, tier: true, monthlyAllotment: true },
   });
 
   if (!org) {
@@ -530,45 +491,21 @@ export async function handleSubscriptionUpdated(event: Stripe.Event) {
   );
 
   if (isCancelling) {
-    const resend = await getResendClient();
-    const owner = await findOrganizationOwner(org.id);
     const cancellationDate = new Date(
-      (subscription.cancel_at || subscription.current_period_end) * 1000
+      ((subscription.cancel_at || subscription.current_period_end) ?? 0) * 1000
     );
 
-    if (owner && resend) {
-      try {
-        await resend.emails.send({
-          from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
-          to: owner.user.email,
-          subject: 'Subscription Cancellation Scheduled',
-          text: `Hi ${owner.user.name || 'there'},
+    await sendBillingLifecycleEmail({
+      organizationId: org.id,
+      subject: 'Subscription cancellation scheduled',
+      text: `Your subscription is scheduled for cancellation.
 
-Your ${org.name} subscription is scheduled to cancel on ${cancellationDate.toLocaleDateString()}.
+Cancellation date: ${cancellationDate.toDateString()}
+After this date your organization will move to the free tier.
 
-After cancellation, your organization will revert to the free tier.
-
-You can review your billing details at:
-${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing
-
-Best regards,
-The Vizora Team`,
-        });
-
-        console.log(
-          `[handleSubscriptionUpdated] Cancellation email sent to ${owner.user.email}`
-        );
-      } catch (error) {
-        console.error(
-          '[handleSubscriptionUpdated] Failed to send cancellation email:',
-          error
-        );
-      }
-    } else if (owner && !resend) {
-      console.log(
-        `[handleSubscriptionUpdated] Would send cancellation email to ${owner.user.email} (Resend not configured)`
-      );
-    }
+Manage billing:
+${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing`,
+    });
   }
 }
 

--- a/editor/src/lib/stripe-handlers.ts
+++ b/editor/src/lib/stripe-handlers.ts
@@ -15,6 +15,20 @@ async function getResendClient() {
   return new Resend(resendApiKey);
 }
 
+async function findOrganizationOwner(organizationId: string) {
+  return prisma.member.findFirst({
+    where: {
+      organizationId,
+      role: 'owner',
+    },
+    include: {
+      user: {
+        select: { email: true, name: true },
+      },
+    },
+  });
+}
+
 export async function handleCheckoutComplete(event: Stripe.Event) {
   const session = event.data.object as Stripe.Checkout.Session;
   const organizationId = session.metadata?.organizationId;
@@ -112,6 +126,44 @@ export async function handleCheckoutComplete(event: Stripe.Event) {
         isolationLevel: 'RepeatableRead',
       }
     );
+
+    const resend = await getResendClient();
+    const owner = await findOrganizationOwner(organizationId);
+
+    if (owner && resend) {
+      try {
+        await resend.emails.send({
+          from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
+          to: owner.user.email,
+          subject: 'Subscription Activated',
+          text: `Hi ${owner.user.name || 'there'},
+
+Welcome to the ${tierConfig.displayName} plan for Vizora.
+
+Monthly allotment: ${tierConfig.monthlyAllotment} credits
+Next billing date: ${cycleEnd.toLocaleDateString()}
+
+You can manage your subscription at:
+${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing
+
+Best regards,
+The Vizora Team`,
+        });
+
+        console.log(
+          `[handleCheckoutComplete] Subscription email sent to ${owner.user.email}`
+        );
+      } catch (error) {
+        console.error(
+          '[handleCheckoutComplete] Failed to send subscription email:',
+          error
+        );
+      }
+    } else if (owner && !resend) {
+      console.log(
+        `[handleCheckoutComplete] Would send subscription email to ${owner.user.email} (Resend not configured)`
+      );
+    }
   }
 
   // Handle credit pack purchase
@@ -121,6 +173,8 @@ export async function handleCheckoutComplete(event: Stripe.Event) {
       console.error('[handleCheckoutComplete] Missing packSize in metadata');
       return;
     }
+
+    let newBalance = 0;
 
     await prisma.$transaction(
       async (tx) => {
@@ -133,7 +187,7 @@ export async function handleCheckoutComplete(event: Stripe.Event) {
           throw new Error(`Organization ${organizationId} not found`);
         }
 
-        const newBalance = org.creditBalance + packSize;
+        newBalance = org.creditBalance + packSize;
 
         await tx.organization.update({
           where: { id: organizationId },
@@ -166,6 +220,45 @@ export async function handleCheckoutComplete(event: Stripe.Event) {
         isolationLevel: 'RepeatableRead',
       }
     );
+
+    const resend = await getResendClient();
+    const owner = await findOrganizationOwner(organizationId);
+
+    if (owner && resend) {
+      try {
+        await resend.emails.send({
+          from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
+          to: owner.user.email,
+          subject: 'Credit Pack Purchased',
+          text: `Hi ${owner.user.name || 'there'},
+
+Your credit pack purchase was successful.
+
+Pack size: ${packSize} credits
+Amount paid: ${((session.amount_total || 0) / 100).toFixed(2)}
+New balance: ${newBalance} credits
+
+View your billing dashboard:
+${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing
+
+Best regards,
+The Vizora Team`,
+        });
+
+        console.log(
+          `[handleCheckoutComplete] Credit pack email sent to ${owner.user.email}`
+        );
+      } catch (error) {
+        console.error(
+          '[handleCheckoutComplete] Failed to send credit pack email:',
+          error
+        );
+      }
+    } else if (owner && !resend) {
+      console.log(
+        `[handleCheckoutComplete] Would send credit pack email to ${owner.user.email} (Resend not configured)`
+      );
+    }
   }
 }
 
@@ -192,6 +285,7 @@ export async function handleInvoicePaid(event: Stripe.Event) {
     where: { stripeCustomerId: customerId },
     select: {
       id: true,
+      name: true,
       creditBalance: true,
       monthlyAllotment: true,
       tier: true,
@@ -209,18 +303,22 @@ export async function handleInvoicePaid(event: Stripe.Event) {
     `[handleInvoicePaid] Processing invoice ${invoice.id} for org ${org.id}`
   );
 
+  let addedCredits = 0;
+  let newBalance = 0;
+  let cycleEnd = addMonths(new Date(), 1);
+
   // Perform credit rollover with 2x cap
   await prisma.$transaction(
     async (tx) => {
       const maxRollover = org.monthlyAllotment * 2;
-      const newBalance = Math.min(
+      newBalance = Math.min(
         org.creditBalance + org.monthlyAllotment,
         maxRollover
       );
-      const addedCredits = newBalance - org.creditBalance;
+      addedCredits = newBalance - org.creditBalance;
 
       const now = new Date();
-      const cycleEnd = addMonths(now, 1);
+      cycleEnd = addMonths(now, 1);
 
       await tx.organization.update({
         where: { id: org.id },
@@ -258,6 +356,40 @@ export async function handleInvoicePaid(event: Stripe.Event) {
       isolationLevel: 'RepeatableRead',
     }
   );
+
+  const resend = await getResendClient();
+  const owner = await findOrganizationOwner(org.id);
+
+  if (owner && resend) {
+    try {
+      await resend.emails.send({
+        from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
+        to: owner.user.email,
+        subject: 'Invoice Renewal Receipt',
+        text: `Hi ${owner.user.name || 'there'},
+
+Your ${org.name} subscription has been renewed successfully.
+
+Credits added: ${addedCredits}
+New balance: ${newBalance} credits
+Next renewal date: ${cycleEnd.toLocaleDateString()}
+
+Manage billing here:
+${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing
+
+Best regards,
+The Vizora Team`,
+      });
+
+      console.log(`[handleInvoicePaid] Email sent to ${owner.user.email}`);
+    } catch (error) {
+      console.error('[handleInvoicePaid] Failed to send email:', error);
+    }
+  } else if (owner && !resend) {
+    console.log(
+      `[handleInvoicePaid] Would send email to ${owner.user.email} (Resend not configured)`
+    );
+  }
 }
 
 export async function handlePaymentFailed(event: Stripe.Event) {
@@ -300,17 +432,7 @@ export async function handlePaymentFailed(event: Stripe.Event) {
   const resend = await getResendClient();
 
   // Send email notification to organization owner
-  const owner = await prisma.member.findFirst({
-    where: {
-      organizationId: org.id,
-      role: 'owner',
-    },
-    include: {
-      user: {
-        select: { email: true, name: true },
-      },
-    },
-  });
+  const owner = await findOrganizationOwner(org.id);
 
   if (owner && resend) {
     try {
@@ -357,7 +479,7 @@ export async function handleSubscriptionUpdated(event: Stripe.Event) {
 
   const org = await prisma.organization.findUnique({
     where: { stripeCustomerId: customerId },
-    select: { id: true, tier: true, monthlyAllotment: true },
+    select: { id: true, name: true, tier: true, monthlyAllotment: true },
   });
 
   if (!org) {
@@ -385,12 +507,17 @@ export async function handleSubscriptionUpdated(event: Stripe.Event) {
   const tierConfig = TIER_CONFIG[tier];
   const tierChanged = tier !== org.tier;
 
+  // Stripe may use cancel_at (specific timestamp) or cancel_at_period_end (boolean)
+  // Treat either as "scheduled for cancellation"
+  const isCancelling =
+    subscription.cancel_at_period_end || subscription.cancel_at !== null;
+
   // Update organization
   await prisma.organization.update({
     where: { id: org.id },
     data: {
       subscriptionStatus: subscription.status,
-      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      cancelAtPeriodEnd: isCancelling,
       ...(tierChanged && {
         tier,
         monthlyAllotment: tierConfig.monthlyAllotment,
@@ -399,8 +526,50 @@ export async function handleSubscriptionUpdated(event: Stripe.Event) {
   });
 
   console.log(
-    `[handleSubscriptionUpdated] Subscription updated: status=${subscription.status}, cancelAtPeriodEnd=${subscription.cancel_at_period_end}${tierChanged ? `, tier changed: ${org.tier} → ${tier}` : ''}`
+    `[handleSubscriptionUpdated] Subscription updated: status=${subscription.status}, cancelAtPeriodEnd=${isCancelling}${tierChanged ? `, tier changed: ${org.tier} → ${tier}` : ''}`
   );
+
+  if (isCancelling) {
+    const resend = await getResendClient();
+    const owner = await findOrganizationOwner(org.id);
+    const cancellationDate = new Date(
+      (subscription.cancel_at || subscription.current_period_end) * 1000
+    );
+
+    if (owner && resend) {
+      try {
+        await resend.emails.send({
+          from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
+          to: owner.user.email,
+          subject: 'Subscription Cancellation Scheduled',
+          text: `Hi ${owner.user.name || 'there'},
+
+Your ${org.name} subscription is scheduled to cancel on ${cancellationDate.toLocaleDateString()}.
+
+After cancellation, your organization will revert to the free tier.
+
+You can review your billing details at:
+${process.env.NEXT_PUBLIC_APP_URL || 'https://vizora.dev'}/dashboard/billing
+
+Best regards,
+The Vizora Team`,
+        });
+
+        console.log(
+          `[handleSubscriptionUpdated] Cancellation email sent to ${owner.user.email}`
+        );
+      } catch (error) {
+        console.error(
+          '[handleSubscriptionUpdated] Failed to send cancellation email:',
+          error
+        );
+      }
+    } else if (owner && !resend) {
+      console.log(
+        `[handleSubscriptionUpdated] Would send cancellation email to ${owner.user.email} (Resend not configured)`
+      );
+    }
+  }
 }
 
 export async function handleSubscriptionDeleted(event: Stripe.Event) {


### PR DESCRIPTION
## Summary
- add owner-facing billing lifecycle emails for Stripe checkout, renewal, and cancellation events
- reuse the existing Resend gating pattern so emails are skipped when no owner or API key is available
- keep billing links and sender handling aligned with the current payment-failed email flow

## Testing
- COREPACK_HOME=/tmp/corepack-home PNPM_HOME=/tmp/pnpm-home XDG_CACHE_HOME=/tmp/xdg-cache HOME=/home/node pnpm check
- COREPACK_HOME=/tmp/corepack-home PNPM_HOME=/tmp/pnpm-home XDG_CACHE_HOME=/tmp/xdg-cache HOME=/home/node pnpm check-types
- COREPACK_HOME=/tmp/corepack-home PNPM_HOME=/tmp/pnpm-home XDG_CACHE_HOME=/tmp/xdg-cache HOME=/home/node pnpm vitest run

Closes #67
