### PR TITLE
fix: harden batch-export endpoint against path traversal and info leakage

### DIFF
--- a/editor/src/__tests__/api/batch-export/route.test.ts
+++ b/editor/src/__tests__/api/batch-export/route.test.ts
@@ -101,8 +101,19 @@ describe('GET /api/batch-export', () => {
   it('passes auth guard and attempts to read files (may 500 in test env)', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'u-1' } });
     const res = await GET(makeGetRequest() as never);
-    // Auth passes — route either succeeds or hits a filesystem error, but NOT 401
     expect(res.status).not.toBe(401);
+  });
+
+  it('does not leak internal paths on GET failure', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u-1' } });
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file /secret/path');
+    });
+    const res = await GET(makeGetRequest() as never);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load animation presets');
+    expect(body.error).not.toContain('ENOENT');
   });
 });
 
@@ -162,7 +173,7 @@ describe('POST /api/batch-export', () => {
     expect(res.status).toBe(400);
   });
 
-  it('accepts a clean filename and attempts to write', async () => {
+  it('accepts a clean filename and does not return server path in response', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'u-1' } });
     mockExistsSync.mockReturnValue(true);
     mockWriteFileSync.mockReturnValue(undefined);
@@ -170,9 +181,27 @@ describe('POST /api/batch-export', () => {
     const res = await POST(
       makePostRequest({ file: blob, filename: 'valid-export-name' }) as never
     );
-    // Should not be 400 or 401 (filesystem write may still error in test env)
+    // Auth + validation pass (filesystem/arrayBuffer may error in test env)
     expect(res.status).not.toBe(400);
     expect(res.status).not.toBe(401);
+    const body = await res.json();
+    expect(body.path).toBeUndefined();
+  });
+
+  it('does not leak internal paths or error details on failure', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u-1' } });
+    mockExistsSync.mockReturnValue(true);
+    mockWriteFileSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+    const blob = new Blob(['data'], { type: 'video/mp4' });
+    const res = await POST(
+      makePostRequest({ file: blob, filename: 'test' }) as never
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Batch export failed');
+    expect(body.error).not.toContain('EACCES');
   });
 
   it('returns 400 when file is missing', async () => {

--- a/editor/src/app/api/batch-export/route.ts
+++ b/editor/src/app/api/batch-export/route.ts
@@ -5,8 +5,11 @@ import {
 } from '@/lib/require-session';
 import { type NextRequest, NextResponse } from 'next/server';
 import fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { z } from 'zod';
+
+const EXPORT_DIR = process.env.RENDER_OUTPUT_DIR || '/tmp/batch-exports';
 
 const batchExportSchema = z.object({
   filename: z
@@ -33,14 +36,13 @@ export async function GET(req: NextRequest) {
       ...presetsContent.matchAll(/animationRegistry\.register\("([^"]+)"/g),
     ].map((m) => m[1]);
 
-    // Also send the data.json template to ensure we always have a clip to render
     const projectTemplatePath = path.join(process.cwd(), 'src/data/data.json');
     const template = JSON.parse(fs.readFileSync(projectTemplatePath, 'utf-8'));
 
     return NextResponse.json({ success: true, keys: animationKeys, template });
-  } catch (error: any) {
+  } catch {
     return NextResponse.json(
-      { success: false, error: error.message },
+      { success: false, error: 'Failed to load animation presets' },
       { status: 500 }
     );
   }
@@ -65,23 +67,23 @@ export async function POST(req: NextRequest) {
     const parsed = batchExportSchema.safeParse({ filename });
     if (!parsed.success) return zodErrorResponse(parsed.error);
 
-    const exportDir = 'D:\\animations';
-    if (!fs.existsSync(exportDir)) {
-      fs.mkdirSync(exportDir, { recursive: true });
+    if (!fs.existsSync(EXPORT_DIR)) {
+      fs.mkdirSync(EXPORT_DIR, { recursive: true });
     }
 
     const buffer = Buffer.from(await file.arrayBuffer());
-    const filePath = path.join(exportDir, `${parsed.data.filename}.mp4`);
+    const safeFilename = `${randomUUID()}.mp4`;
+    const filePath = path.join(EXPORT_DIR, safeFilename);
     fs.writeFileSync(filePath, buffer);
 
     return NextResponse.json({
       success: true,
-      path: filePath,
+      filename: `${parsed.data.filename}.mp4`,
     });
-  } catch (error: any) {
+  } catch (error) {
     console.error('Batch export error:', error);
     return NextResponse.json(
-      { success: false, error: error.message },
+      { success: false, error: 'Batch export failed' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
Fixes #56 — Batch export endpoint writes to hardcoded path with arbitrary filenames.

## Security Issues Fixed
1. **Hardcoded Windows path** -- Replaced `D:\\animations` with `RENDER_OUTPUT_DIR` env var (falls back to `/tmp/batch-exports`), consistent with the render-worker pattern.
2. **Arbitrary file write** -- Server now generates UUID-based filenames instead of using user-supplied names. The user's original filename is still validated via Zod but only returned in the response metadata, never used for disk writes.
3. **Error message leakage** -- Both GET and POST handlers now return generic error strings instead of exposing `error.message` (which could leak internal paths and stack details).
4. **Path leakage in response** -- The `path` field (which exposed the server filesystem path) is no longer returned; replaced with `filename` (the user's original name + extension).

## Tests
- Added test verifying GET handler masks internal errors
- Added test verifying POST handler masks internal errors
- Updated existing test to verify no `path` field in response
- All 11 batch-export tests pass, plus 21 auth-guards smoke tests