### PR TITLE
fix: replace catch(error: any) with catch(error: unknown)

### DIFF
--- a/editor/src/app/api/batch-export/route.ts
+++ b/editor/src/app/api/batch-export/route.ts
@@ -38,9 +38,12 @@ export async function GET(req: NextRequest) {
     const template = JSON.parse(fs.readFileSync(projectTemplatePath, 'utf-8'));
 
     return NextResponse.json({ success: true, keys: animationKeys, template });
-  } catch (error: any) {
+  } catch (error: unknown) {
     return NextResponse.json(
-      { success: false, error: error.message },
+      {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
       { status: 500 }
     );
   }
@@ -78,10 +81,13 @@ export async function POST(req: NextRequest) {
       success: true,
       path: filePath,
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Batch export error:', error);
     return NextResponse.json(
-      { success: false, error: error.message },
+      {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
       { status: 500 }
     );
   }

--- a/editor/src/components/editor/timeline/timeline/clips/video.ts
+++ b/editor/src/components/editor/timeline/timeline/clips/video.ts
@@ -207,14 +207,15 @@ export class Video extends BaseTimelineClip {
       if (!signal.aborted && this.canvas) {
         this.canvas.requestRenderAll();
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       this._isFetchingThumbnails = false;
 
       // Ignore expected abort errors
       if (
-        error?.name === 'AbortError' ||
-        error?.message === 'generate thumbnails aborted' ||
-        error?.message?.includes('aborted')
+        error instanceof Error &&
+        (error.name === 'AbortError' ||
+          error.message === 'generate thumbnails aborted' ||
+          error.message.includes('aborted'))
       ) {
         return;
       }


### PR DESCRIPTION
## Summary
- Replaced `catch (error: any)` with `catch (error: unknown)` in batch-export route and video timeline clip
- Used `error instanceof Error ? error.message : String(error)` for safe message access
- Follows TypeScript strict mode best practices

Closes #75, #71

## Test plan
- [ ] pnpm check-types passes
- [ ] pnpm check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)