### PR TITLE
fix(security): sanitize HTML in email templates

### DIFF
--- a/editor/src/workers/deletion-warning-worker.ts
+++ b/editor/src/workers/deletion-warning-worker.ts
@@ -2,6 +2,15 @@ import { Worker } from 'bullmq';
 import { prisma } from '@/lib/db';
 import { redisConnection } from '@/lib/redis';
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 const worker = new Worker(
   'deletion-warnings',
   async (job) => {
@@ -37,10 +46,10 @@ const worker = new Worker(
         from: process.env.RESEND_FROM_EMAIL || 'noreply@vizora.dev',
         to: render.user.email,
         subject: `Your rendered video expires ${expiresAt}`,
-        html: `<p>Hi ${render.user.name || 'there'},</p>
-        <p>Your rendered video "${render.template.name}" will be automatically deleted on <strong>${expiresAt}</strong>.</p>
+        html: `<p>Hi ${escapeHtml(render.user.name || 'there')},</p>
+        <p>Your rendered video "${escapeHtml(render.template.name)}" will be automatically deleted on <strong>${expiresAt}</strong>.</p>
         <p>If you need this video, please download it before it expires.</p>
-        <p>${render.outputUrl ? `<a href="${render.outputUrl}">Download Video</a>` : ''}</p>
+        <p>${render.outputUrl && /^https?:\/\//.test(render.outputUrl) ? `<a href="${escapeHtml(render.outputUrl)}">Download Video</a>` : ''}</p>
         <p>— Vizora</p>`,
       });
       console.log(


### PR DESCRIPTION
## Summary
- Added `escapeHtml()` utility to prevent HTML injection in deletion-warning email templates
- Sanitized all user-controlled interpolations (`user.name`, `template.name`) with HTML entity encoding
- Added URL protocol validation (`https?://`) for `outputUrl` before rendering into href attributes
- Searched all other worker email templates — only this file was affected

Closes #23

## Test plan
- [x] `pnpm check-types` passes
- [ ] `pnpm check` passes
- [ ] Manual: verify email templates render correctly with special characters in names (e.g., `<script>`, `"quotes"`, `&ampersands`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)