### PR TITLE
fix(security): harden batch-export and remove error detail leakage

### DIFF
--- a/editor/src/app/api/ai/subtitles/route.ts
+++ b/editor/src/app/api/ai/subtitles/route.ts
@@ -122,14 +122,14 @@ export async function POST(request: NextRequest) {
 
       if (error.message.includes('transcribe')) {
         return NextResponse.json(
-          { error: 'Failed to transcribe audio', details: error.message },
+          { error: 'Failed to transcribe audio' },
           { status: 500 }
         );
       }
     }
 
     return NextResponse.json(
-      { error: 'Failed to generate subtitles', details: String(error) },
+      { error: 'Failed to generate subtitles' },
       { status: 500 }
     );
   }

--- a/editor/src/app/api/ai/template/refine/route.ts
+++ b/editor/src/app/api/ai/template/refine/route.ts
@@ -89,20 +89,6 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Template refinement error:', error);
 
-    if (error instanceof Error) {
-      // Check for specific error types
-      if (error.message.includes('AI template refinement failed')) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
-
-      return NextResponse.json(
-        {
-          error: `Template refinement failed: ${error.message}`,
-        },
-        { status: 500 }
-      );
-    }
-
     return NextResponse.json(
       { error: 'An unexpected error occurred during template refinement' },
       { status: 500 }

--- a/editor/src/app/api/ai/template/route.ts
+++ b/editor/src/app/api/ai/template/route.ts
@@ -84,20 +84,6 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Template generation error:', error);
 
-    if (error instanceof Error) {
-      // Check for specific error types
-      if (error.message.includes('AI template generation failed')) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
-
-      return NextResponse.json(
-        {
-          error: `Template generation failed: ${error.message}`,
-        },
-        { status: 500 }
-      );
-    }
-
     return NextResponse.json(
       { error: 'An unexpected error occurred during template generation' },
       { status: 500 }

--- a/editor/src/app/api/ai/text-to-video/route.ts
+++ b/editor/src/app/api/ai/text-to-video/route.ts
@@ -89,10 +89,7 @@ export async function POST(req: NextRequest) {
     console.error('Text-to-video generation error:', error);
 
     return NextResponse.json(
-      {
-        error: 'Failed to generate video composition',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
+      { error: 'Failed to generate video composition' },
       { status: 500 }
     );
   }

--- a/editor/src/app/api/ai/tts/route.ts
+++ b/editor/src/app/api/ai/tts/route.ts
@@ -104,18 +104,12 @@ export async function POST(req: NextRequest) {
       provider,
     });
   } catch (error) {
-    if (error instanceof Error) {
-      // Check for specific provider errors
-      if (error.message.includes('not configured')) {
-        return NextResponse.json(
-          { error: 'Provider not configured', details: error.message },
-          { status: 503 }
-        );
-      }
+    console.error('[TTS] Error:', error);
 
+    if (error instanceof Error && error.message.includes('not configured')) {
       return NextResponse.json(
-        { error: 'Failed to generate speech', details: error.message },
-        { status: 500 }
+        { error: 'Provider not configured' },
+        { status: 503 }
       );
     }
 

--- a/editor/src/app/api/ai/voices/route.ts
+++ b/editor/src/app/api/ai/voices/route.ts
@@ -99,8 +99,9 @@ export async function GET(req: NextRequest) {
     }
 
     // All providers failed
+    console.error('[Voices] All providers failed:', errors);
     return NextResponse.json(
-      { error: 'Failed to fetch voices from all providers', details: errors },
+      { error: 'Failed to fetch voices from all providers' },
       { status: 500 }
     );
   } catch (error) {

--- a/editor/src/app/api/assets/[...path]/route.ts
+++ b/editor/src/app/api/assets/[...path]/route.ts
@@ -59,11 +59,9 @@ export async function GET(
       },
     });
   } catch (error) {
+    console.error('[Assets] Error:', error);
     return NextResponse.json(
-      {
-        error: 'Failed to fetch asset',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
+      { error: 'Failed to fetch asset' },
       { status: 500 }
     );
   }

--- a/editor/src/app/api/batch-export/route.ts
+++ b/editor/src/app/api/batch-export/route.ts
@@ -1,23 +1,9 @@
-import {
-  requireSession,
-  unauthorizedResponse,
-  zodErrorResponse,
-} from '@/lib/require-session';
+import { requireSession, unauthorizedResponse } from '@/lib/require-session';
 import { type NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { z } from 'zod';
-
-const batchExportSchema = z.object({
-  filename: z
-    .string()
-    .min(1)
-    .max(255)
-    .refine(
-      (val) => !/[/\\]/.test(val) && !val.includes('..') && !val.includes('\0'),
-      'Filename must not contain path separators, "..", or null bytes'
-    ),
-});
 
 export async function GET(req: NextRequest) {
   const session = await requireSession(req);
@@ -38,9 +24,10 @@ export async function GET(req: NextRequest) {
     const template = JSON.parse(fs.readFileSync(projectTemplatePath, 'utf-8'));
 
     return NextResponse.json({ success: true, keys: animationKeys, template });
-  } catch (error: any) {
+  } catch (error) {
+    console.error('[BatchExport GET] Error:', error);
     return NextResponse.json(
-      { success: false, error: error.message },
+      { success: false, error: 'Internal server error' },
       { status: 500 }
     );
   }
@@ -53,7 +40,6 @@ export async function POST(req: NextRequest) {
   try {
     const formData = await req.formData();
     const file = formData.get('file') as Blob;
-    const filename = formData.get('filename') as string;
 
     if (!file) {
       return NextResponse.json(
@@ -62,26 +48,34 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const parsed = batchExportSchema.safeParse({ filename });
-    if (!parsed.success) return zodErrorResponse(parsed.error);
+    const exportDir =
+      process.env.RENDER_OUTPUT_DIR || path.join(os.tmpdir(), 'vizora-exports');
+    const resolvedDir = path.resolve(exportDir);
+    if (!fs.existsSync(resolvedDir)) {
+      fs.mkdirSync(resolvedDir, { recursive: true });
+    }
 
-    const exportDir = 'D:\\animations';
-    if (!fs.existsSync(exportDir)) {
-      fs.mkdirSync(exportDir, { recursive: true });
+    const serverFilename = `${randomUUID()}.mp4`;
+    const filePath = path.resolve(resolvedDir, serverFilename);
+
+    // Guard against path traversal
+    if (!filePath.startsWith(resolvedDir)) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid file path' },
+        { status: 400 }
+      );
     }
 
     const buffer = Buffer.from(await file.arrayBuffer());
-    const filePath = path.join(exportDir, `${parsed.data.filename}.mp4`);
     fs.writeFileSync(filePath, buffer);
 
     return NextResponse.json({
       success: true,
-      path: filePath,
     });
-  } catch (error: any) {
-    console.error('Batch export error:', error);
+  } catch (error) {
+    console.error('[BatchExport POST] Error:', error);
     return NextResponse.json(
-      { success: false, error: error.message },
+      { success: false, error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/editor/src/app/api/uploads/presign/route.ts
+++ b/editor/src/app/api/uploads/presign/route.ts
@@ -52,10 +52,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Error in presign route:', error);
     return NextResponse.json(
-      {
-        error: 'Internal server error',
-        details: error instanceof Error ? error.message : String(error),
-      },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- Replaced hardcoded `D:\animations` path with `RENDER_OUTPUT_DIR` env var / temp directory in batch-export
- Generated server-side filenames (UUID) instead of user-supplied names
- Removed leaked server paths from success responses
- Removed `error.message` / `details` from client-facing error responses across 9 API routes
- Added server-side error logging with console.error

Closes #56, #41

## Test plan
- [ ] pnpm check-types passes
- [ ] pnpm check passes
- [ ] Verify batch-export endpoint works with new path logic
- [ ] Verify error responses no longer contain internal details

🤖 Generated with [Claude Code](https://claude.com/claude-code)