### PR TITLE
refactor: type Prisma queries in v1 API routes

### DIFF
--- a/editor/src/app/api/v1/assets/route.ts
+++ b/editor/src/app/api/v1/assets/route.ts
@@ -2,6 +2,7 @@ import { withApiAuth, type ApiKeyContext } from '@/lib/api-middleware';
 import { config } from '@/lib/config';
 import { prisma } from '@/lib/db';
 import { R2StorageService } from '@/lib/r2';
+import type { Prisma } from '@prisma/client';
 import { z } from 'zod';
 
 // Initialize R2 service
@@ -125,7 +126,7 @@ async function getHandler(
     const limit = Math.min(limitParam, 100); // Cap at 100
 
     // Build where clause with organization scope
-    const where: any = {
+    const where: Prisma.AssetWhereInput = {
       organizationId: context.organizationId,
     };
 
@@ -137,12 +138,18 @@ async function getHandler(
     }
 
     // Filter by category
-    if (category && assetCategories.includes(category as any)) {
+    if (
+      category &&
+      assetCategories.includes(category as (typeof assetCategories)[number])
+    ) {
       where.category = category;
     }
 
     // Build pagination options
-    const paginationOptions: any = {
+    const paginationOptions: Omit<
+      Prisma.AssetFindManyArgs,
+      'where' | 'include' | 'select'
+    > = {
       orderBy: { createdAt: 'desc' },
       take: limit + 1, // Fetch one extra to check for more
     };
@@ -173,8 +180,8 @@ async function getHandler(
     const nextCursor = hasMore ? items[items.length - 1].id : null;
 
     // Build folder path breadcrumb data for each item
-    const responseItems = items.map((asset: any) => {
-      const item: any = {
+    const responseItems = items.map((asset) => {
+      const item: Record<string, unknown> = {
         id: asset.id,
         name: asset.name,
         contentType: asset.contentType,

--- a/editor/src/app/api/v1/renders/route.ts
+++ b/editor/src/app/api/v1/renders/route.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { withApiAuth, type ApiKeyContext } from '@/lib/api-middleware';
 import { prisma } from '@/lib/db';
+import type { Prisma } from '@prisma/client';
 import { renderQueue } from '@/lib/queue';
 import { validateMergeData } from '@/lib/template-schema';
 import type { MergeField } from '@/types/template';
@@ -272,7 +273,7 @@ async function getHandler(
     const limit = Math.min(limitParam, 100); // Cap at 100
 
     // Build where clause with organization scope
-    const where: any = {
+    const where: Prisma.RenderWhereInput = {
       organizationId: context.organizationId,
     };
 
@@ -288,18 +289,27 @@ async function getHandler(
       where.templateId = templateId;
     }
 
+    const queuedAtFilter: Prisma.DateTimeFilter<'Render'> = {};
+    let hasQueuedAtFilter = false;
+
     if (fromDate) {
       const date = new Date(fromDate);
       if (!Number.isNaN(date.getTime())) {
-        where.queuedAt = { ...where.queuedAt, gte: date };
+        queuedAtFilter.gte = date;
+        hasQueuedAtFilter = true;
       }
     }
 
     if (toDate) {
       const date = new Date(toDate);
       if (!Number.isNaN(date.getTime())) {
-        where.queuedAt = { ...where.queuedAt, lte: date };
+        queuedAtFilter.lte = date;
+        hasQueuedAtFilter = true;
       }
+    }
+
+    if (hasQueuedAtFilter) {
+      where.queuedAt = queuedAtFilter;
     }
 
     // Fetch renders with pagination
@@ -329,7 +339,7 @@ async function getHandler(
 
     // Map to response format (exclude mergeData)
     const responseItems = items.map((render) => {
-      const item: any = {
+      const item: Record<string, unknown> = {
         id: render.id,
         status: render.status,
         templateId: render.templateId,


### PR DESCRIPTION
## Summary
- Replaced `any` types with proper Prisma types in v1 assets and renders routes
- Used `Prisma.AssetWhereInput` and `Prisma.RenderWhereInput` for query building
- Typed pagination options with `Prisma.AssetFindManyArgs`
- Properly typed response item mappings with `Record<string, unknown>`
- Fixed enum casting through tuple type instead of `as any`
- Fixed date filter spreading with explicit `Prisma.DateTimeFilter<'Render'>`

Closes #47, #46

## Test plan
- [x] pnpm check-types passes
- [x] pnpm check passes
- [ ] v1 API endpoints return correct data with filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)