### PR TITLE
fix(security): add auth to presign endpoint and scope asset proxy

### DIFF
--- a/editor/src/__tests__/api/uploads/presign/route.test.ts
+++ b/editor/src/__tests__/api/uploads/presign/route.test.ts
@@ -73,9 +73,19 @@ describe('POST /api/uploads/presign', () => {
     vi.clearAllMocks();
   });
 
-  // Auth guards not yet implemented — see issue #17
-  it.todo('returns 401 when no session exists');
-  it.todo('returns 401 when session has no user id');
+  it('returns 401 when no session exists', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ fileNames: ['video.mp4'] }) as never);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when session has no user id', async () => {
+    mockGetSession.mockResolvedValue({ user: {} });
+
+    const res = await POST(makeRequest({ fileNames: ['video.mp4'] }) as never);
+    expect(res.status).toBe(401);
+  });
 
   it('returns 400 when fileNames is missing', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'user-1' } });
@@ -111,10 +121,18 @@ describe('POST /api/uploads/presign', () => {
     expect(body.uploads[0].presignedUrl).toContain('presign');
   });
 
-  // Auth guard not yet implemented — userId comes from body, not session (see issue #17)
-  it.todo(
-    'uses session.user.id in the R2 key path, not a body-supplied userId'
-  );
+  it('uses session.user.id in the R2 key path, not a body-supplied userId', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'session-user-99' } });
+    mockCreatePresignedUpload.mockResolvedValue(mockPresignResult('test.mp4'));
+
+    await POST(
+      makeRequest({ fileNames: ['test.mp4'], userId: 'attacker-id' }) as never
+    );
+
+    const callArg = mockCreatePresignedUpload.mock.calls[0][0] as string;
+    expect(callArg).toContain('session-user-99');
+    expect(callArg).not.toContain('attacker-id');
+  });
 
   it('returns 200 for multiple fileNames', async () => {
     mockCreatePresignedUpload

--- a/editor/src/app/api/assets/[...path]/route.ts
+++ b/editor/src/app/api/assets/[...path]/route.ts
@@ -1,6 +1,9 @@
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { type NextRequest, NextResponse } from 'next/server';
 
+/** Only these R2 key prefixes are publicly accessible. */
+const ALLOWED_PREFIXES = ['assets/', 'renders/'];
+
 const s3Client = new S3Client({
   region: 'auto',
   endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
@@ -16,12 +19,21 @@ export async function GET(
 ) {
   try {
     const { path: pathArray } = await params;
-    const path = pathArray.join('/');
+    const key = pathArray.join('/');
+
+    // Block path traversal and restrict to known public prefixes
+    if (
+      key.includes('..') ||
+      key.includes('\0') ||
+      !ALLOWED_PREFIXES.some((prefix) => key.startsWith(prefix))
+    ) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
 
     // Fetch from R2
     const command = new GetObjectCommand({
       Bucket: process.env.R2_BUCKET_NAME || '',
-      Key: path,
+      Key: key,
     });
 
     const response = await s3Client.send(command);
@@ -59,11 +71,9 @@ export async function GET(
       },
     });
   } catch (error) {
+    console.error('[assets/proxy] Error:', error);
     return NextResponse.json(
-      {
-        error: 'Failed to fetch asset',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
+      { error: 'Failed to fetch asset' },
       { status: 500 }
     );
   }

--- a/editor/src/app/api/uploads/presign/route.ts
+++ b/editor/src/app/api/uploads/presign/route.ts
@@ -1,12 +1,20 @@
 import { randomUUID } from 'node:crypto';
 import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { config } from '@/lib/config';
 import { R2StorageService } from '@/lib/r2';
+import {
+  requireSession,
+  unauthorizedResponse,
+  zodErrorResponse,
+} from '@/lib/require-session';
 
-interface PresignRequest {
-  userId: string;
-  fileNames: string[];
-}
+const presignSchema = z.object({
+  fileNames: z
+    .array(z.string().min(1).max(255))
+    .min(1, 'fileNames must not be empty')
+    .max(20, 'Maximum 20 files per request'),
+});
 
 const r2 = new R2StorageService({
   bucketName: config.r2.bucket,
@@ -17,16 +25,16 @@ const r2 = new R2StorageService({
 });
 
 export async function POST(request: NextRequest) {
-  try {
-    const body: PresignRequest = await request.json();
-    const { userId = 'mockuser', fileNames } = body;
+  const session = await requireSession(request);
+  if (!session) return unauthorizedResponse();
 
-    if (!fileNames || !Array.isArray(fileNames) || fileNames.length === 0) {
-      return NextResponse.json(
-        { error: 'fileNames array is required and must not be empty' },
-        { status: 400 }
-      );
-    }
+  try {
+    const body = await request.json();
+    const parsed = presignSchema.safeParse(body);
+    if (!parsed.success) return zodErrorResponse(parsed.error);
+
+    const userId = session.user.id;
+    const { fileNames } = parsed.data;
 
     const uploads = await Promise.all(
       fileNames.map(async (originalName) => {
@@ -50,12 +58,9 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ success: true, uploads });
   } catch (error) {
-    console.error('Error in presign route:', error);
+    console.error('[presign] Error:', error);
     return NextResponse.json(
-      {
-        error: 'Internal server error',
-        details: error instanceof Error ? error.message : String(error),
-      },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- **#17 — Presigned upload**: Added `requireSession()` auth guard. UserId now derived from authenticated session instead of request body (was defaulting to `'mockuser'`). Added Zod schema validation for `fileNames` (max 20 files, 255 chars each). Removed error detail leakage.
- **#18 — R2 asset proxy**: Restricted to `assets/` and `renders/` key prefixes only (was open to entire bucket). Added path traversal protection (`..`, null bytes). Removed error detail leakage.
- Implemented 3 previously-TODO test cases for auth guards — all 8 tests pass.

Closes #17, #18

## Test plan
- [x] `pnpm check-types` passes
- [x] 8/8 presign route tests pass (including 3 new auth tests)
- [ ] Manual: verify editor file uploads still work with session auth
- [ ] Manual: verify `/api/assets/renders/...` and `/api/assets/assets/...` paths work
- [ ] Manual: verify `/api/assets/secret/...` returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)