### PR TITLE
fix(security): harden batch-export and remove error detail leakage

### DIFF
--- a/editor/src/app/api/ai/subtitles/route.ts
+++ b/editor/src/app/api/ai/subtitles/route.ts
@@ -122,14 +122,14 @@ export async function POST(request: NextRequest) {
 
       if (error.message.includes('transcribe')) {
         return NextResponse.json(
-          { error: 'Failed to transcribe audio', details: error.message },
+          { error: 'Failed to transcribe audio' },
           { status: 500 }
         );
       }
     }
 
     return NextResponse.json(
-      { error: 'Failed to generate subtitles', details: String(error) },
+      { error: 'Failed to generate subtitles' },
       { status: 500 }
     );
   }

--- a/editor/src/app/api/ai/template/refine/route.ts
+++ b/editor/src/app/api/ai/template/refine/route.ts
@@ -61,20 +61,6 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Template refinement error:', error);
 
-    if (error instanceof Error) {
-      // Check for specific error types
-      if (error.message.includes('AI template refinement failed')) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
-
-      return NextResponse.json(
-        {
-          error: `Template refinement failed: ${error.message}`,
-        },
-        { status: 500 }
-      );
-    }
-
     return NextResponse.json(
       { error: 'An unexpected error occurred during template refinement' },
       { status: 500 }

--- a/editor/src/app/api/ai/template/route.ts
+++ b/editor/src/app/api/ai/template/route.ts
@@ -69,20 +69,6 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Template generation error:', error);
 
-    if (error instanceof Error) {
-      // Check for specific error types
-      if (error.message.includes('AI template generation failed')) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
-
-      return NextResponse.json(
-        {
-          error: `Template generation failed: ${error.message}`,
-        },
-        { status: 500 }
-      );
-    }
-
     return NextResponse.json(
       { error: 'An unexpected error occurred during template generation' },
       { status: 500 }

--- a/editor/src/app/api/ai/text-to-video/route.ts
+++ b/editor/src/app/api/ai/text-to-video/route.ts
@@ -91,7 +91,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(
       {
         error: 'Failed to generate video composition',
-        details: error instanceof Error ? error.message : 'Unknown error',
       },
       { status: 500 }
     );

--- a/editor/src/app/api/ai/voices/route.ts
+++ b/editor/src/app/api/ai/voices/route.ts
@@ -83,9 +83,8 @@ export async function GET(req: NextRequest) {
 
         allVoices.push(...voices);
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : 'Unknown error';
-        errors.push(`${provider}: ${errorMessage}`);
+        console.error(`Voice provider ${provider} error:`, error);
+        errors.push(provider);
       }
     }
 
@@ -100,7 +99,7 @@ export async function GET(req: NextRequest) {
 
     // All providers failed
     return NextResponse.json(
-      { error: 'Failed to fetch voices from all providers', details: errors },
+      { error: 'Failed to fetch voices from all providers' },
       { status: 500 }
     );
   } catch (error) {

--- a/editor/src/app/api/batch-export/route.ts
+++ b/editor/src/app/api/batch-export/route.ts
@@ -3,8 +3,10 @@ import {
   unauthorizedResponse,
   zodErrorResponse,
 } from '@/lib/require-session';
+import crypto from 'node:crypto';
 import { type NextRequest, NextResponse } from 'next/server';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { z } from 'zod';
 
@@ -39,10 +41,11 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ success: true, keys: animationKeys, template });
   } catch (error: unknown) {
+    console.error('Batch export GET error:', error);
     return NextResponse.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: 'Failed to load animation presets',
       },
       { status: 500 }
     );
@@ -68,25 +71,34 @@ export async function POST(req: NextRequest) {
     const parsed = batchExportSchema.safeParse({ filename });
     if (!parsed.success) return zodErrorResponse(parsed.error);
 
-    const exportDir = 'D:\\animations';
+    const exportDir = process.env.RENDER_OUTPUT_DIR || os.tmpdir();
     if (!fs.existsSync(exportDir)) {
       fs.mkdirSync(exportDir, { recursive: true });
     }
 
+    const serverFilename = `${crypto.randomUUID()}.mp4`;
+    const filePath = path.resolve(exportDir, serverFilename);
+
+    // Guard against path traversal — resolved path must stay within exportDir
+    if (!filePath.startsWith(path.resolve(exportDir))) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid export path' },
+        { status: 400 }
+      );
+    }
+
     const buffer = Buffer.from(await file.arrayBuffer());
-    const filePath = path.join(exportDir, `${parsed.data.filename}.mp4`);
     fs.writeFileSync(filePath, buffer);
 
     return NextResponse.json({
       success: true,
-      path: filePath,
     });
   } catch (error: unknown) {
     console.error('Batch export error:', error);
     return NextResponse.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: 'Failed to export file',
       },
       { status: 500 }
     );


### PR DESCRIPTION
## Summary
- Replaced hardcoded `D:\animations` path with env-var/temp directory in batch-export
- Generated server-side filenames (UUID) instead of user-supplied names
- Added path.resolve() guard against path traversal
- Removed error detail leakage from remaining API routes
- Added server-side error logging

Closes #56, #41

## Test plan
- [ ] pnpm check-types passes
- [ ] pnpm check passes
- [ ] Batch-export endpoint works with new path logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)