### PR TITLE
fix(security): validate webhook URL IP at delivery time to prevent SSRF

### DIFF
--- a/editor/src/lib/webhooks/validator.ts
+++ b/editor/src/lib/webhooks/validator.ts
@@ -7,7 +7,7 @@ import { isIP } from 'node:net';
  * Check if an IP address is private or reserved
  * Blocks RFC 1918 private ranges and other reserved ranges
  */
-function isPrivateOrReservedIP(ip: string): boolean {
+export function isPrivateOrReservedIP(ip: string): boolean {
   // Only IPv4 for now (IPv6 would need :: handling)
   const parts = ip.split('.').map(Number);
 

--- a/editor/src/workers/webhook-worker.ts
+++ b/editor/src/workers/webhook-worker.ts
@@ -1,7 +1,9 @@
+import { resolve4 } from 'node:dns/promises';
 import { Worker, type Job, UnrecoverableError } from 'bullmq';
 import { request } from 'undici';
 import { prisma } from '@/lib/db';
 import { redisConnection } from '@/lib/redis';
+import { isPrivateOrReservedIP } from '@/lib/webhooks/validator';
 import { generateWebhookSignature } from '@/lib/webhooks/signature';
 import type { WebhookJobData } from '@/lib/webhooks/types';
 
@@ -25,6 +27,27 @@ async function processWebhookDelivery(job: Job<WebhookJobData>) {
   if (!config || !config.enabled) {
     console.log(
       `[Webhook Worker] Webhook ${webhookConfigId} not found or disabled, skipping delivery`
+    );
+    return;
+  }
+
+  // SSRF protection: resolve hostname and validate IP at delivery time
+  // This prevents DNS rebinding attacks where the IP changes after registration
+  const hostname = new URL(config.url).hostname;
+  try {
+    const addresses = await resolve4(hostname);
+    const blockedAddress = addresses.find((ip) => isPrivateOrReservedIP(ip));
+    if (blockedAddress) {
+      console.warn(
+        `[Webhook Worker] SSRF blocked: ${hostname} resolved to private/reserved IP ${blockedAddress}, skipping delivery for webhook ${webhookConfigId}`
+      );
+      return;
+    }
+  } catch (dnsError) {
+    // DNS resolution failed — skip delivery to avoid sending to an unknown target
+    console.warn(
+      `[Webhook Worker] DNS resolution failed for ${hostname}, skipping delivery for webhook ${webhookConfigId}:`,
+      dnsError instanceof Error ? dnsError.message : dnsError
     );
     return;
   }


### PR DESCRIPTION
## Summary
- Added IP validation at webhook delivery time (not just registration)
- Resolves hostname via DNS before sending, checks against private/reserved IP ranges
- Prevents DNS rebinding attacks that bypass registration-time URL validation
- Blocks requests to internal services (169.254.x.x metadata, 127.0.0.1, private networks)

Closes #24

## Test plan
- [ ] pnpm check-types passes
- [ ] Webhooks to public URLs still deliver correctly
- [ ] Webhooks to private IPs are blocked with warning log

🤖 Generated with [Claude Code](https://claude.com/claude-code)