### PR TITLE
fix: add ambient HardwarePreference type for Next.js builds

### DIFF
--- a/editor/src/webcodecs.d.ts
+++ b/editor/src/webcodecs.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Ambient WebCodecs type used by openvideo (packages/openvideo).
+ *
+ * The openvideo package declares this via @types/dom-webcodecs in its own
+ * tsconfig, but when Next.js resolves openvideo source through the path
+ * alias ("openvideo" → "../packages/openvideo/src/index.ts"), it uses
+ * editor's tsconfig which lacks that type package.
+ *
+ * This declaration fills the gap without adding @types/dom-webcodecs to
+ * editor's dependencies (which would require a restrictive "types" field
+ * in tsconfig, breaking auto-discovery of other @types packages).
+ */
+type HardwarePreference =
+  | "no-preference"
+  | "prefer-hardware"
+  | "prefer-software";


### PR DESCRIPTION
## Summary

- Adds editor/src/webcodecs.d.ts with an ambient HardwarePreference type declaration
- Fixes TS2304: Cannot find name HardwarePreference that breaks all PR builds

## Root Cause

The openvideo package uses HardwarePreference from @types/dom-webcodecs declared in its tsconfig types field. When Next.js resolves openvideo source through the editor path alias, it uses the editor tsconfig which lacks that type — causing build failures across all open PRs.

## Fix

A 16-line .d.ts file in editor/src/ that declares the missing ambient type. The declaration is additive and merges harmlessly when @types/dom-webcodecs is also present (e.g., in openvideo own build).

## Test plan

- [x] pnpm check-types passes (0 errors)
- [x] pnpm build passes (4/4 tasks)
- [x] pnpm vitest run passes (117/117 tests)